### PR TITLE
CRAB-21879: Add a tag_instances command to Nagbot

### DIFF
--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -1,5 +1,5 @@
 __author__ = "Stephen Rosenthal"
-__version__ = "1.6.0"
+__version__ = "1.7.0"
 __license__ = "MIT"
 
 import argparse
@@ -12,13 +12,16 @@ from . import parsing
 from . import sqaws
 from . import sqslack
 
-TERMINATION_WARNING_DAYS = 3
-
 TODAY = datetime.today()
 TODAY_YYYY_MM_DD = TODAY.strftime('%Y-%m-%d')
 TODAY_IS_WEEKEND = TODAY.weekday() >= 4  # Days are 0-6. 4=Friday, 5=Saturday, 6=Sunday, 0=Monday
 YESTERDAY_YYYY_MM_DD = (TODAY - timedelta(days=1)).strftime('%Y-%m-%d')
 MIN_TERMINATION_WARNING_YYYY_MM_DD = (TODAY - timedelta(days=3)).strftime('%Y-%m-%d')
+
+AUTO_STOP_AFTER_DAYS = 3
+AUTO_STOP_AFTER_DAY_YYYY_MM_DD = (TODAY + timedelta(days=AUTO_STOP_AFTER_DAYS)).strftime('%Y-%m-%d')
+AUTO_TERMINATE_AFTER_DAYS = 14
+AUTO_TERMINATE_AFTER_DAY_YYYY_MM_DD = (TODAY + timedelta(days=AUTO_TERMINATE_AFTER_DAYS)).strftime('%Y-%m-%d')
 
 """
 PREREQUISITES:
@@ -30,7 +33,29 @@ PREREQUISITES:
 
 
 class Nagbot(object):
-    def notify_internal(self, channel):
+
+    def _tag_instances_internal(self, channel):
+        instances = sqaws.list_ec2_instances()
+        instances_to_tag = get_taggable_instances(instances)
+
+        if len(instances_to_tag) > 0:
+            message = 'I tagged the following instances to be stopped or terminated: '
+            for i in instances_to_tag:
+                contact = sqslack.lookup_user_by_email(i.contact)
+                message += '\n' + make_instance_summary(i) + ', Contact={}'.format(contact)
+                tag_instance(i)
+            sqslack.send_message(channel, message)
+        else:
+            sqslack.send_message(channel, 'No instances were tagged today.')
+
+    def tag_instances(self, channel):
+        try:
+            self._tag_instances_internal(channel)
+        except Exception as e:
+            sqslack.send_message(channel, "Nagbot failed to run the 'tag_instances' command: " + str(e))
+            raise (e)
+
+    def _notify_internal(self, channel):
         instances = sqaws.list_ec2_instances()
 
         num_running_instances = sum(1 for i in instances if i.state == 'running')
@@ -39,7 +64,7 @@ class Nagbot(object):
 
         summary_msg = "Hi, I'm Nagbot v{} :wink: My job is to make sure we don't forget about unwanted AWS servers and waste money!\n".format(__version__)
         summary_msg += "We have {} running EC2 instances right now and {} total.\n".format(num_running_instances,
-                                                                                                num_total_instances)
+                                                                                           num_total_instances)
         summary_msg += "If we continue to run these instances all month, it would cost {}.\n" \
             .format(running_monthly_cost)
 
@@ -74,7 +99,7 @@ class Nagbot(object):
 
         instances_to_stop = get_stoppable_instances(instances)
         if len(instances_to_stop) > 0:
-            stop_msg ='The following %d _running_ instances are due to be *STOPPED*, based on the "Stop after" tag:\n' % len(instances_to_stop)
+            stop_msg = 'The following %d _running_ instances are due to be *STOPPED*, based on the "Stop after" tag:\n' % len(instances_to_stop)
             for i in instances_to_stop:
                 contact = sqslack.lookup_user_by_email(i.contact)
                 stop_msg += make_instance_summary(i) + ', "Stop after"={}, "Monthly Price"={}, Contact={}\n' \
@@ -85,16 +110,14 @@ class Nagbot(object):
             stop_msg = 'No instances are due to be stopped at this time.\n'
         sqslack.send_message(channel, stop_msg)
 
-
     def notify(self, channel):
         try:
-            self.notify_internal(channel)
+            self._notify_internal(channel)
         except Exception as e:
             sqslack.send_message(channel, "Nagbot failed to run the 'notify' command: " + str(e))
-            raise(e)
+            raise (e)
 
-
-    def execute_internal(self, channel):
+    def _execute_internal(self, channel):
         instances = sqaws.list_ec2_instances()
 
         # Only terminate instances which still meet the criteria for terminating, AND were warned several times
@@ -128,13 +151,35 @@ class Nagbot(object):
         else:
             sqslack.send_message(channel, 'No instances were stopped today.')
 
-
     def execute(self, channel):
         try:
-            self.execute_internal(channel)
+            self._execute_internal(channel)
         except Exception as e:
             sqslack.send_message(channel, "Nagbot failed to run the 'execute' command: " + str(e))
-            raise(e)
+            raise (e)
+
+
+def get_taggable_instances(instances):
+    return list(i for i in instances if is_taggable(i))
+
+
+def is_taggable(instance):
+    return (not is_whitelisted(instance) and
+            (not instance.stop_after
+             or not instance.terminate_after
+             or (not parsing.parse_date_tag(instance.terminate_after).expiry_date
+                 and not parsing.parse_date_tag(instance.terminate_after).warning_date)))
+
+
+def tag_instance(instance):
+    if not instance.stop_after:
+        sqaws.set_tag(instance.region_name, instance.instance_id, 'Stop after',
+                      AUTO_STOP_AFTER_DAY_YYYY_MM_DD)
+    if (not instance.terminate_after
+            or (not parsing.parse_date_tag(instance.terminate_after).expiry_date
+                and not parsing.parse_date_tag(instance.terminate_after).warning_date)):
+        sqaws.set_tag(instance.region_name, instance.instance_id, 'Terminate after',
+                      AUTO_TERMINATE_AFTER_DAY_YYYY_MM_DD)
 
 
 def get_stoppable_instances(instances):
@@ -145,7 +190,7 @@ def is_stoppable(instance):
     parsed_date: parsing.ParsedDate = parsing.parse_date_tag(instance.stop_after)
 
     return instance.state == 'running' and (
-            (parsed_date.expiry_date is None) # Treat unspecified "Stop after" dates as being in the past
+            (parsed_date.expiry_date is None)  # Treat unspecified "Stop after" dates as being in the past
             or (TODAY_IS_WEEKEND and parsed_date.on_weekends) \
             or (TODAY_YYYY_MM_DD >= parsed_date.expiry_date))
 
@@ -157,9 +202,10 @@ def get_terminatable_instances(instances):
 def is_terminatable(instance):
     parsed_date: parsing.ParsedDate = parsing.parse_date_tag(instance.terminate_after)
 
-    # For now, we'll only terminate instances which have an explicit 'Terminate after' tag
+    # We'll only terminate instances which have an explicit 'Terminate after' tag. That will only be automatically
+    # added if the tag_instances stage has been run.
     return instance.state == 'stopped' and (
-            (parsed_date.expiry_date is not None and TODAY_YYYY_MM_DD >= parsed_date.expiry_date))
+        (parsed_date.expiry_date is not None and TODAY_YYYY_MM_DD >= parsed_date.expiry_date))
 
 
 # Some instances are whitelisted from stop or terminate actions. These won't show up as recommended to stop/terminate.
@@ -217,21 +263,24 @@ def main(args):
 
     nagbot = Nagbot()
 
+    if mode.lower() == 'tag_instances':
+        nagbot.tag_instances(channel)
     if mode.lower() == 'notify':
         nagbot.notify(channel)
     elif mode.lower() == 'execute':
         nagbot.execute(channel)
     else:
-        print('Unexpected mode "%s", should be "notify" or "execute"' % mode)
+        print('Unexpected mode "%s", should be "tag_instances", "notify", or "execute"' % mode)
         sys.exit(1)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "mode", help="Mode, either 'notify' or 'execute'. "
-        "In 'notify' mode, a notification is posted to Slack. "
-        "In 'execute' mode, instances are stopped or terminated.")
+        "mode", help="Mode, either 'tag_instances', 'notify', or 'execute'. "
+                     "In 'tag_instances' mode, instances are auto-marked with a stop and terminate date. "
+                     "In 'notify' mode, a notification is posted to Slack. "
+                     "In 'execute' mode, instances are stopped or terminated.")
 
     parser.add_argument(
         "-c",

--- a/tests/test_nagbot.py
+++ b/tests/test_nagbot.py
@@ -24,7 +24,7 @@ class TestNagbot(unittest.TestCase):
                         contact='stephen',
                         nagbot_state='')
 
-    def test_taggable(self):
+    def test_tags_missing(self):
         valid_date = '2019-01-01'
         fully_tagged = self.setup_instance(stop_after=valid_date, terminate_after=valid_date)
         warning_terminate = self.setup_instance(stop_after=valid_date,
@@ -37,22 +37,37 @@ class TestNagbot(unittest.TestCase):
                                                 terminate_after='Pope Paul pleases proletariat people')
 
         # These have something in stop_after and some kind of date for terminate_after
-        assert nagbot.is_taggable(fully_tagged) == False
-        assert nagbot.is_taggable(warning_terminate) == False
-        assert nagbot.is_taggable(unknown_stop) == False    # This one will get stopped due to the warning system
+        assert fully_tagged.is_stop_after_tag_missing() is False
+        assert fully_tagged.is_terminate_after_tag_missing() is False
+        assert fully_tagged.is_terminate_after_tag_missing() is False
+
+        assert warning_terminate.is_stop_after_tag_missing() is False
+        assert warning_terminate.is_terminate_after_tag_missing() is False
+        # This one will get stopped due to the warning system
+        assert unknown_stop.is_stop_after_tag_missing() is False
+        assert unknown_stop.is_terminate_after_tag_missing() is False
 
         # stop_after should be filled in if it's not present
-        assert nagbot.is_taggable(empty_stop) == True
+        assert empty_stop.is_stop_after_tag_missing() is True
+        assert empty_stop.is_terminate_after_tag_missing() is False
 
         # terminate_after should be filled in if it's not present
-        assert nagbot.is_taggable(empty_terminate) == True
+        assert empty_terminate.is_stop_after_tag_missing() is False
+        assert empty_terminate.is_terminate_after_tag_missing() is True
 
         # stop_after and terminate_after should be filled in if they're not present
-        assert nagbot.is_taggable(empty_stop_and_terminate) == True
+        assert empty_stop_and_terminate.is_stop_after_tag_missing() is True
+        assert empty_stop_and_terminate.is_terminate_after_tag_missing() is True
 
         # terminate_after must have some kind of date in it
-        assert nagbot.is_taggable(unknown_terminate) == True
+        assert unknown_terminate.is_stop_after_tag_missing() is False
+        assert unknown_terminate.is_terminate_after_tag_missing() is True
 
+        # Test the get_taggable_instances() only returns the instances that result in True above
+        all_instances = [fully_tagged, warning_terminate, unknown_stop, empty_stop, empty_terminate,
+                         empty_stop_and_terminate, unknown_terminate]
+        taggable_instances = [empty_stop, empty_terminate, empty_stop_and_terminate, unknown_terminate]
+        self.assertListEqual(nagbot.get_taggable_instances(all_instances), taggable_instances)
 
     def test_stoppable(self):
         past_date = self.setup_instance(state='running', stop_after='2019-01-01')
@@ -68,28 +83,28 @@ class TestNagbot(unittest.TestCase):
         unknown_date = self.setup_instance(state='running', stop_after='TBD')
 
         # These instances should get a stop warning
-        assert nagbot.is_stoppable(past_date) == True
-        assert nagbot.is_stoppable(today_date) == True
-        assert nagbot.is_stoppable(unknown_date) == True
-        assert nagbot.is_stoppable(past_date_warned) == True
-        assert nagbot.is_stoppable(today_date_warned) == True
-        assert nagbot.is_stoppable(anything_warned) == True
+        assert nagbot.is_stoppable(past_date) is True
+        assert nagbot.is_stoppable(today_date) is True
+        assert nagbot.is_stoppable(unknown_date) is True
+        assert nagbot.is_stoppable(past_date_warned) is True
+        assert nagbot.is_stoppable(today_date_warned) is True
+        assert nagbot.is_stoppable(anything_warned) is True
 
         # These instances should NOT get a stop warning
-        assert nagbot.is_stoppable(wrong_state) == False
-        assert nagbot.is_stoppable(future_date) == False
+        assert nagbot.is_stoppable(wrong_state) is False
+        assert nagbot.is_stoppable(future_date) is False
 
         # These instances don't have a warning, so they shouldn't be stopped yet
-        assert nagbot.is_safe_to_stop(past_date) == False
-        assert nagbot.is_safe_to_stop(today_date) == False
-        assert nagbot.is_safe_to_stop(unknown_date) == False
-        assert nagbot.is_safe_to_stop(wrong_state) == False
-        assert nagbot.is_safe_to_stop(future_date) == False
+        assert nagbot.is_safe_to_stop(past_date) is False
+        assert nagbot.is_safe_to_stop(today_date) is False
+        assert nagbot.is_safe_to_stop(unknown_date) is False
+        assert nagbot.is_safe_to_stop(wrong_state) is False
+        assert nagbot.is_safe_to_stop(future_date) is False
 
         # These instances can be stopped right away
-        assert nagbot.is_safe_to_stop(past_date_warned) == True
-        assert nagbot.is_safe_to_stop(today_date_warned) == True
-        assert nagbot.is_safe_to_stop(anything_warned) == True
+        assert nagbot.is_safe_to_stop(past_date_warned) is True
+        assert nagbot.is_safe_to_stop(today_date_warned) is True
+        assert nagbot.is_safe_to_stop(anything_warned) is True
 
     def test_terminatable(self):
         past_date = self.setup_instance(state='stopped', terminate_after='2019-01-01')
@@ -111,34 +126,34 @@ class TestNagbot(unittest.TestCase):
         unknown_date = self.setup_instance(state='stopped', terminate_after='TBD')
 
         # These instances should get a termination warning
-        assert nagbot.is_terminatable(past_date) == True
-        assert nagbot.is_terminatable(today_date) == True
-        assert nagbot.is_terminatable(past_date_warned) == True
-        assert nagbot.is_terminatable(today_date_warned) == True
+        assert nagbot.is_terminatable(past_date) is True
+        assert nagbot.is_terminatable(today_date) is True
+        assert nagbot.is_terminatable(past_date_warned) is True
+        assert nagbot.is_terminatable(today_date_warned) is True
 
         # These instances should NOT get a termination warning
-        assert nagbot.is_terminatable(wrong_state) == False
-        assert nagbot.is_terminatable(future_date) == False
-        assert nagbot.is_terminatable(unknown_date) == False
-        assert nagbot.is_terminatable(anything_warned) == False
+        assert nagbot.is_terminatable(wrong_state) is False
+        assert nagbot.is_terminatable(future_date) is False
+        assert nagbot.is_terminatable(unknown_date) is False
+        assert nagbot.is_terminatable(anything_warned) is False
 
         # These instances don't have a warning, so they shouldn't be terminated yet
-        assert nagbot.is_safe_to_terminate(past_date) == False
-        assert nagbot.is_safe_to_terminate(today_date) == False
-        assert nagbot.is_safe_to_terminate(unknown_date) == False
-        assert nagbot.is_safe_to_terminate(wrong_state) == False
-        assert nagbot.is_safe_to_terminate(future_date) == False
-        assert nagbot.is_safe_to_terminate(anything_warned) == False
+        assert nagbot.is_safe_to_terminate(past_date) is False
+        assert nagbot.is_safe_to_terminate(today_date) is False
+        assert nagbot.is_safe_to_terminate(unknown_date) is False
+        assert nagbot.is_safe_to_terminate(wrong_state) is False
+        assert nagbot.is_safe_to_terminate(future_date) is False
+        assert nagbot.is_safe_to_terminate(anything_warned) is False
 
         # These instances can be terminated, but not yet
-        assert nagbot.is_safe_to_terminate(past_date_warned) == False
-        assert nagbot.is_safe_to_terminate(today_date_warned) == False
+        assert nagbot.is_safe_to_terminate(past_date_warned) is False
+        assert nagbot.is_safe_to_terminate(today_date_warned) is False
 
         # These instances have a warning, but are not eligible to add a warning, so we don't terminate
-        assert nagbot.is_safe_to_terminate(anything_warned_days_ago) == False
+        assert nagbot.is_safe_to_terminate(anything_warned_days_ago) is False
 
         # These instances can be terminated now
-        assert nagbot.is_safe_to_terminate(past_date_warned_days_ago) == True
+        assert nagbot.is_safe_to_terminate(past_date_warned_days_ago) is True
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds a new `tag_instances` command to Nagbot. It's intended to run shortly before `notify` in the mornings. 

If `Stop after` tag is not present, it will be set to three days in the future. If `Terminate after` is not set to a valid date, it will be set to two weeks in the future. A slack message will be sent if any instances get new tags added. 

----------------

I hope to extend this new command in the future to parse the instance `Name`, look for any known names within Seeq, and automatically add a Contact email. E.G. an instance named "Dak's manual testing" would be able to automatically add my email address as the contact.