### PR TITLE
CRAB-30171: Added support for tags without spaces per AWS update

### DIFF
--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -132,7 +132,7 @@ class Nagbot(object):
                 message = message + make_instance_summary(i) + ', "Stop after"={}, "Monthly Price"={}, Contact={}\n' \
                     .format(i.stop_after, money_to_string(i.monthly_price), contact)
                 sqaws.stop_instance(i.region_name, i.instance_id, dryrun=dryrun)
-                sqaws.set_tag(i.region_name, i.instance_id, 'Nagbot State', 'Stopped on ' + TODAY_YYYY_MM_DD,
+                sqaws.set_tag(i.region_name, i.instance_id, i.nagbot_state_tag_name, 'Stopped on ' + TODAY_YYYY_MM_DD,
                               dryrun=dryrun)
             sqslack.send_message(channel, message)
         else:

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -73,7 +73,7 @@ class Nagbot(object):
                 contact = sqslack.lookup_user_by_email(i.contact)
                 terminate_msg += make_instance_summary(i) + ', "Terminate after"={}, "Monthly Price"={}, Contact={}\n' \
                     .format(i.terminate_after, money_to_string(i.monthly_price), contact)
-                sqaws.set_tag(i.region_name, i.instance_id, 'Terminate after',
+                sqaws.set_tag(i.region_name, i.instance_id, 'TerminateAfter',
                               parsing.add_warning_to_tag(i.terminate_after, TODAY_YYYY_MM_DD), dryrun=dryrun)
         else:
             terminate_msg = 'No instances are due to be terminated at this time.\n'
@@ -87,7 +87,7 @@ class Nagbot(object):
                 contact = sqslack.lookup_user_by_email(i.contact)
                 stop_msg += make_instance_summary(i) + ', "Stop after"={}, "Monthly Price"={}, Contact={}\n' \
                     .format(i.stop_after, money_to_string(i.monthly_price), contact)
-                sqaws.set_tag(i.region_name, i.instance_id, 'Stop after',
+                sqaws.set_tag(i.region_name, i.instance_id, 'StopAfter',
                               parsing.add_warning_to_tag(i.stop_after, TODAY_YYYY_MM_DD, replace=True), dryrun=dryrun)
         else:
             stop_msg = 'No instances are due to be stopped at this time.\n'

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -73,7 +73,7 @@ class Nagbot(object):
                 contact = sqslack.lookup_user_by_email(i.contact)
                 terminate_msg += make_instance_summary(i) + ', "Terminate after"={}, "Monthly Price"={}, Contact={}\n' \
                     .format(i.terminate_after, money_to_string(i.monthly_price), contact)
-                sqaws.set_tag(i.region_name, i.instance_id, 'TerminateAfter',
+                sqaws.set_tag(i.region_name, i.instance_id, i.terminate_after_str,
                               parsing.add_warning_to_tag(i.terminate_after, TODAY_YYYY_MM_DD), dryrun=dryrun)
         else:
             terminate_msg = 'No instances are due to be terminated at this time.\n'
@@ -87,7 +87,7 @@ class Nagbot(object):
                 contact = sqslack.lookup_user_by_email(i.contact)
                 stop_msg += make_instance_summary(i) + ', "Stop after"={}, "Monthly Price"={}, Contact={}\n' \
                     .format(i.stop_after, money_to_string(i.monthly_price), contact)
-                sqaws.set_tag(i.region_name, i.instance_id, 'StopAfter',
+                sqaws.set_tag(i.region_name, i.instance_id, i.stop_after_str,
                               parsing.add_warning_to_tag(i.stop_after, TODAY_YYYY_MM_DD, replace=True), dryrun=dryrun)
         else:
             stop_msg = 'No instances are due to be stopped at this time.\n'

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -73,7 +73,7 @@ class Nagbot(object):
                 contact = sqslack.lookup_user_by_email(i.contact)
                 terminate_msg += make_instance_summary(i) + ', "Terminate after"={}, "Monthly Price"={}, Contact={}\n' \
                     .format(i.terminate_after, money_to_string(i.monthly_price), contact)
-                sqaws.set_tag(i.region_name, i.instance_id, i.terminate_after_str,
+                sqaws.set_tag(i.region_name, i.instance_id, i.terminate_after_tag_name,
                               parsing.add_warning_to_tag(i.terminate_after, TODAY_YYYY_MM_DD), dryrun=dryrun)
         else:
             terminate_msg = 'No instances are due to be terminated at this time.\n'
@@ -87,7 +87,7 @@ class Nagbot(object):
                 contact = sqslack.lookup_user_by_email(i.contact)
                 stop_msg += make_instance_summary(i) + ', "Stop after"={}, "Monthly Price"={}, Contact={}\n' \
                     .format(i.stop_after, money_to_string(i.monthly_price), contact)
-                sqaws.set_tag(i.region_name, i.instance_id, i.stop_after_str,
+                sqaws.set_tag(i.region_name, i.instance_id, i.stop_after_tag_name,
                               parsing.add_warning_to_tag(i.stop_after, TODAY_YYYY_MM_DD, replace=True), dryrun=dryrun)
         else:
             stop_msg = 'No instances are due to be stopped at this time.\n'

--- a/app/sqaws.py
+++ b/app/sqaws.py
@@ -108,9 +108,7 @@ def build_instance_model(pricing: PricingData, region_name: str, instance_dict: 
     monthly_storage_price = estimate_monthly_ebs_storage_price(region_name, instance_dict['InstanceId'])
     monthly_price = (monthly_server_price + monthly_storage_price) if state == 'running' else monthly_storage_price
 
-    stop_terminate = get_stop_and_terminate_after(tags)
-    stop_after = stop_terminate[0]
-    terminate_after = stop_terminate[1]
+    stop_after, terminate_after = get_stop_and_terminate_after(tags)
     contact = tags.get('Contact', '')
     nagbot_state = tags.get('Nagbot State', '')
 
@@ -132,14 +130,14 @@ def build_instance_model(pricing: PricingData, region_name: str, instance_dict: 
 
 
 # Find 'stop after' and 'terminate after' fields in an EC2 instance, regardless of formatting
-def get_stop_and_terminate_after(tags: dict) -> list:
-    stop_terminate = ['', '']
-    for key in tags:
-        if (key.lower()).startswith('stop'):
-            stop_terminate[0] = tags.get(key)
-        if (key.lower()).startswith('terminate'):
-            stop_terminate[1] = tags.get(key)
-    return stop_terminate
+def get_stop_and_terminate_after(tags: dict) -> tuple[str, str]:
+    stop_after, terminate_after = '', ''
+    for key, value in tags.items():
+        if (key.lower()).startswith('stop') and 'after' in (key.lower()):
+            stop_after = value
+        if (key.lower()).startswith('terminate') and 'after' in (key.lower()):
+            terminate_after = value
+    return stop_after, terminate_after
 
 
 # Convert the tags list returned from the EC2 API to a dictionary from tag name to tag value

--- a/app/sqaws.py
+++ b/app/sqaws.py
@@ -111,7 +111,7 @@ def build_instance_model(pricing: PricingData, region_name: str, instance_dict: 
     monthly_storage_price = estimate_monthly_ebs_storage_price(region_name, instance_dict['InstanceId'])
     monthly_price = (monthly_server_price + monthly_storage_price) if state == 'running' else monthly_storage_price
 
-    stop_after_tag_name, terminate_after_tag_name, nagbot_state_tag_name = get_stop_and_terminate_after(tags)
+    stop_after_tag_name, terminate_after_tag_name, nagbot_state_tag_name = get_tag_names(tags)
     stop_after = tags.get(stop_after_tag_name, '')
     terminate_after = tags.get(terminate_after_tag_name, '')
     contact = tags.get('Contact', '')
@@ -137,8 +137,8 @@ def build_instance_model(pricing: PricingData, region_name: str, instance_dict: 
                     nagbot_state_tag_name=nagbot_state_tag_name)
 
 
-# Find 'stop after' and 'terminate after' fields in an EC2 instance, regardless of formatting
-def get_stop_and_terminate_after(tags: dict) -> tuple[str, str, str]:
+# Get 'stop after', 'terminate after', and 'Nagbot state' tag names in an EC2 instance, regardless of formatting
+def get_tag_names(tags: dict) -> tuple[str, str, str]:
     stop_after_tag_name, terminate_after_tag_name, nagbot_state_tag_name = 'StopAfter', 'TerminateAfter', 'NagbotState'
     for key, value in tags.items():
         if (key.lower()).startswith('stop') and 'after' in (key.lower()):

--- a/app/sqaws.py
+++ b/app/sqaws.py
@@ -108,8 +108,9 @@ def build_instance_model(pricing: PricingData, region_name: str, instance_dict: 
     monthly_storage_price = estimate_monthly_ebs_storage_price(region_name, instance_dict['InstanceId'])
     monthly_price = (monthly_server_price + monthly_storage_price) if state == 'running' else monthly_storage_price
 
-    stop_after = tags.get('Stop after', tags.get('Stop After', tags.get('StopAfter', '')))
-    terminate_after = tags.get('Terminate after', tags.get('Terminate After', tags.get('TerminateAfter', '')))
+    stop_terminate = get_stop_and_terminate_after(tags)
+    stop_after = stop_terminate[0]
+    terminate_after = stop_terminate[1]
     contact = tags.get('Contact', '')
     nagbot_state = tags.get('Nagbot State', '')
 
@@ -128,6 +129,17 @@ def build_instance_model(pricing: PricingData, region_name: str, instance_dict: 
                     terminate_after=terminate_after,
                     contact=contact,
                     nagbot_state=nagbot_state)
+
+
+# Find 'stop after' and 'terminate after' fields in an EC2 instance, regardless of formatting
+def get_stop_and_terminate_after(tags: dict) -> list:
+    stop_terminate = ['', '']
+    for key in tags:
+        if (key.lower()).startswith('stop'):
+            stop_terminate[0] = tags.get(key)
+        if (key.lower()).startswith('terminate'):
+            stop_terminate[1] = tags.get(key)
+    return stop_terminate
 
 
 # Convert the tags list returned from the EC2 API to a dictionary from tag name to tag value

--- a/app/sqaws.py
+++ b/app/sqaws.py
@@ -32,8 +32,8 @@ class Instance:
     monthly_price: float
     monthly_server_price: float
     monthly_storage_price: float
-    stop_after_str: str
-    terminate_after_str: str
+    stop_after_tag_name: str
+    terminate_after_tag_name: str
 
     @staticmethod
     def to_header() -> [str]:
@@ -110,15 +110,9 @@ def build_instance_model(pricing: PricingData, region_name: str, instance_dict: 
     monthly_storage_price = estimate_monthly_ebs_storage_price(region_name, instance_dict['InstanceId'])
     monthly_price = (monthly_server_price + monthly_storage_price) if state == 'running' else monthly_storage_price
 
-    stop_after_str, terminate_after_str = get_stop_and_terminate_after(tags)
-    if stop_after_str == '':
-        stop_after = ''
-    else:
-        stop_after = tags.get(stop_after_str)
-    if terminate_after_str == '':
-        terminate_after = ''
-    else:
-        terminate_after = tags.get(terminate_after_str)
+    stop_after_tag_name, terminate_after_tag_name = get_stop_and_terminate_after(tags)
+    stop_after = tags.get(stop_after_tag_name, '')
+    terminate_after = tags.get(terminate_after_tag_name, '')
     contact = tags.get('Contact', '')
     nagbot_state = tags.get('Nagbot State', '')
 
@@ -137,19 +131,19 @@ def build_instance_model(pricing: PricingData, region_name: str, instance_dict: 
                     terminate_after=terminate_after,
                     contact=contact,
                     nagbot_state=nagbot_state,
-                    stop_after_str=stop_after_str,
-                    terminate_after_str=terminate_after_str)
+                    stop_after_tag_name=stop_after_tag_name,
+                    terminate_after_tag_name=terminate_after_tag_name)
 
 
 # Find 'stop after' and 'terminate after' fields in an EC2 instance, regardless of formatting
 def get_stop_and_terminate_after(tags: dict) -> tuple[str, str]:
-    stop_after, terminate_after = '', ''
+    stop_after_tag_name, terminate_after_tag_name = 'StopAfter', 'TerminateAfter'
     for key, value in tags.items():
         if (key.lower()).startswith('stop') and 'after' in (key.lower()):
-            stop_after = key
+            stop_after_tag_name = key
         if (key.lower()).startswith('terminate') and 'after' in (key.lower()):
-            terminate_after = key
-    return stop_after, terminate_after
+            terminate_after_tag_name = key
+    return stop_after_tag_name, terminate_after_tag_name
 
 
 # Convert the tags list returned from the EC2 API to a dictionary from tag name to tag value

--- a/app/sqaws.py
+++ b/app/sqaws.py
@@ -138,7 +138,7 @@ def build_instance_model(pricing: PricingData, region_name: str, instance_dict: 
 
 
 # Get 'stop after', 'terminate after', and 'Nagbot state' tag names in an EC2 instance, regardless of formatting
-def get_tag_names(tags: dict) -> tuple[str, str, str]:
+def get_tag_names(tags: dict) -> tuple:
     stop_after_tag_name, terminate_after_tag_name, nagbot_state_tag_name = 'StopAfter', 'TerminateAfter', 'NagbotState'
     for key, value in tags.items():
         if (key.lower()).startswith('stop') and 'after' in (key.lower()):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ boto3==1.20.26
 slackclient==2.9.3
 pygsheets==2.0.5
 pytest==7.1.2
-mock==4.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 boto3==1.20.26
 slackclient==2.9.3
 pygsheets==2.0.5
+pytest==7.1.2
+mock==4.0.3

--- a/tests/test_nagbot.py
+++ b/tests/test_nagbot.py
@@ -24,7 +24,8 @@ class TestNagbot(unittest.TestCase):
                         nagbot_state='',
                         eks_nodegroup_name='',
                         stop_after_tag_name=stop_after_tag_name,
-                        terminate_after_tag_name=terminate_after_tag_name)
+                        terminate_after_tag_name=terminate_after_tag_name,
+                        nagbot_state_tag_name='NagbotState')
 
     def test_stoppable(self):
         past_date = self.setup_instance(state='running', stop_after='2019-01-01')

--- a/tests/test_nagbot.py
+++ b/tests/test_nagbot.py
@@ -6,8 +6,8 @@ from app.sqaws import Instance
 
 class TestNagbot(unittest.TestCase):
     @staticmethod
-    def setup_instance(state: str, stop_after: str = '', terminate_after: str = '', stop_after_str: str = '',
-                       terminate_after_str: str = ''):
+    def setup_instance(state: str, stop_after: str = '', terminate_after: str = '',
+                       stop_after_tag_name: str = '', terminate_after_tag_name: str = ''):
         return Instance(region_name='us-east-1',
                         instance_id='abc123',
                         state=state,
@@ -23,8 +23,8 @@ class TestNagbot(unittest.TestCase):
                         contact='stephen',
                         nagbot_state='',
                         eks_nodegroup_name='',
-                        stop_after_str=stop_after_str,
-                        terminate_after_str=terminate_after_str)
+                        stop_after_tag_name=stop_after_tag_name,
+                        terminate_after_tag_name=terminate_after_tag_name)
 
     def test_stoppable(self):
         past_date = self.setup_instance(state='running', stop_after='2019-01-01')
@@ -121,20 +121,20 @@ class TestNagbot(unittest.TestCase):
         assert nagbot.is_safe_to_terminate(past_date_warned_days_ago) is True
 
     def test_instance_stop_terminate_str(self):
-        lowercase_instance = self.setup_instance(state='running', stop_after_str='stopafter',
-                                                 terminate_after_str='terminateafter')
-        uppercase_instance = self.setup_instance(state='running', stop_after_str='STOPAFTER',
-                                                 terminate_after_str='TERMINATEAFTER')
-        mixed_case_instance = self.setup_instance(state='running', stop_after_str='StopAfter',
-                                                  terminate_after_str='TerminateAfter')
+        lowercase_instance = self.setup_instance(state='running', stop_after_tag_name='stopafter',
+                                                 terminate_after_tag_name='terminateafter')
+        uppercase_instance = self.setup_instance(state='running', stop_after_tag_name='STOPAFTER',
+                                                 terminate_after_tag_name='TERMINATEAFTER')
+        mixed_case_instance = self.setup_instance(state='running', stop_after_tag_name='StopAfter',
+                                                  terminate_after_tag_name='TerminateAfter')
 
         # Ensure stop_after_str and terminate_after_str fields are correct in each instance
-        assert lowercase_instance.stop_after_str == 'stopafter'
-        assert lowercase_instance.terminate_after_str == 'terminateafter'
-        assert uppercase_instance.stop_after_str == 'STOPAFTER'
-        assert uppercase_instance.terminate_after_str == 'TERMINATEAFTER'
-        assert mixed_case_instance.stop_after_str == 'StopAfter'
-        assert mixed_case_instance.terminate_after_str == 'TerminateAfter'
+        assert lowercase_instance.stop_after_tag_name == 'stopafter'
+        assert lowercase_instance.terminate_after_tag_name == 'terminateafter'
+        assert uppercase_instance.stop_after_tag_name == 'STOPAFTER'
+        assert uppercase_instance.terminate_after_tag_name == 'TERMINATEAFTER'
+        assert mixed_case_instance.stop_after_tag_name == 'StopAfter'
+        assert mixed_case_instance.terminate_after_tag_name == 'TerminateAfter'
 
 
 if __name__ == '__main__':

--- a/tests/test_nagbot.py
+++ b/tests/test_nagbot.py
@@ -6,7 +6,8 @@ from app.sqaws import Instance
 
 class TestNagbot(unittest.TestCase):
     @staticmethod
-    def setup_instance(state: str, stop_after: str = '', terminate_after: str = ''):
+    def setup_instance(state: str, stop_after: str = '', terminate_after: str = '', stop_after_str: str = '',
+                       terminate_after_str: str = ''):
         return Instance(region_name='us-east-1',
                         instance_id='abc123',
                         state=state,
@@ -21,7 +22,9 @@ class TestNagbot(unittest.TestCase):
                         terminate_after=terminate_after,
                         contact='stephen',
                         nagbot_state='',
-                        eks_nodegroup_name='')
+                        eks_nodegroup_name='',
+                        stop_after_str=stop_after_str,
+                        terminate_after_str=terminate_after_str)
 
     def test_stoppable(self):
         past_date = self.setup_instance(state='running', stop_after='2019-01-01')
@@ -116,6 +119,22 @@ class TestNagbot(unittest.TestCase):
 
         # These instances can be terminated now
         assert nagbot.is_safe_to_terminate(past_date_warned_days_ago) is True
+
+    def test_instance_stop_terminate_str(self):
+        lowercase_instance = self.setup_instance(state='running', stop_after_str='stopafter',
+                                                 terminate_after_str='terminateafter')
+        uppercase_instance = self.setup_instance(state='running', stop_after_str='STOPAFTER',
+                                                 terminate_after_str='TERMINATEAFTER')
+        mixed_case_instance = self.setup_instance(state='running', stop_after_str='StopAfter',
+                                                  terminate_after_str='TerminateAfter')
+
+        # Ensure stop_after_str and terminate_after_str fields are correct in each instance
+        assert lowercase_instance.stop_after_str == 'stopafter'
+        assert lowercase_instance.terminate_after_str == 'terminateafter'
+        assert uppercase_instance.stop_after_str == 'STOPAFTER'
+        assert uppercase_instance.terminate_after_str == 'TERMINATEAFTER'
+        assert mixed_case_instance.stop_after_str == 'StopAfter'
+        assert mixed_case_instance.terminate_after_str == 'TerminateAfter'
 
 
 if __name__ == '__main__':

--- a/tests/test_sqaws.py
+++ b/tests/test_sqaws.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest.mock import patch
 
 import app.sqaws
@@ -97,7 +96,7 @@ def test_terminate_instance_exception(mock_client):
 
 
 @pytest.mark.parametrize('stop_terminate_dict, expected_stop_result, expected_terminate_result, '
-                         'expected_stop_str, expected_terminate_str', [
+                         'expected_stop_tag_name, expected_terminate_tag_name', [
                              ({'stop after': '2022-05-10', 'terminate after': '2022-05-11'}, '2022-05-10', '2022-05-11',
                               'stop after', 'terminate after'),
                              ({'Stop After': '2030-07-23', 'Terminate After': '2050-08-10'}, '2030-07-23', '2050-08-10',
@@ -121,17 +120,20 @@ def test_terminate_instance_exception(mock_client):
                              ({'stop.after': '2021-03-04', '': '2022-09-12'}, '2021-03-04', '', 'stop.after', '')
                          ])
 def test_stop_and_terminate_after(stop_terminate_dict, expected_stop_result,
-                                  expected_terminate_result, expected_stop_str, expected_terminate_str):
-    stop_after_str, terminate_after_str = app.sqaws.get_stop_and_terminate_after(stop_terminate_dict)
-    if stop_after_str == '':
-        stop_after = ''
+                                  expected_terminate_result, expected_stop_tag_name, expected_terminate_tag_name):
+    stop_after_tag_name, terminate_after_tag_name = app.sqaws.get_stop_and_terminate_after(stop_terminate_dict)
+    stop_after = stop_terminate_dict.get(stop_after_tag_name, '')
+    terminate_after = stop_terminate_dict.get(terminate_after_tag_name, '')
+
+    assert stop_after == expected_stop_result
+    assert terminate_after == expected_terminate_result
+
+    # Ensure tag name is set to default if empty string is passed in, otherwise should be the specified tag name
+    if expected_stop_tag_name == '':
+        assert stop_after_tag_name == 'StopAfter'
     else:
-        stop_after = stop_terminate_dict.get(stop_after_str)
-    if terminate_after_str == '':
-        terminate_after = ''
+        assert stop_after_tag_name == expected_stop_tag_name
+    if expected_terminate_tag_name == '':
+        assert terminate_after_tag_name == 'TerminateAfter'
     else:
-        terminate_after = stop_terminate_dict.get(terminate_after_str)
-    assert (stop_after == expected_stop_result)
-    assert (terminate_after == expected_terminate_result)
-    assert (stop_after_str == expected_stop_str)
-    assert (terminate_after_str == expected_terminate_str)
+        assert terminate_after_tag_name == expected_terminate_tag_name

--- a/tests/test_sqaws.py
+++ b/tests/test_sqaws.py
@@ -95,47 +95,47 @@ def test_terminate_instance_exception(mock_client):
     mock_ec2.terminate_instances.assert_called_once_with(InstanceIds=[instance_id])
 
 
-@pytest.mark.parametrize('stop_terminate_dict, expected_stop_result, expected_terminate_result, '
-                         'expected_stop_tag_name, expected_terminate_tag_name', [
-                             ({'stop after': '2022-05-10', 'terminate after': '2022-05-11'}, '2022-05-10', '2022-05-11',
-                              'stop after', 'terminate after'),
-                             ({'Stop After': '2030-07-23', 'Terminate After': '2050-08-10'}, '2030-07-23', '2050-08-10',
-                              'Stop After', 'Terminate After'),
-                             ({'STOP AFTER': '2021-03-04', 'TERMINATE AFTER': '2022-09-12'}, '2021-03-04', '2022-09-12',
-                              'STOP AFTER', 'TERMINATE AFTER'),
-                             ({'stop_after': '2022-05-10', 'terminate_after': '2022-05-11'}, '2022-05-10', '2022-05-11',
-                              'stop_after', 'terminate_after'),
-                             ({'Stop_After': '2030-07-23', 'Terminate_After': '2050-08-10'}, '2030-07-23', '2050-08-10',
-                              'Stop_After', 'Terminate_After'),
-                             ({'STOP_AFTER': '2021-03-04', 'TERMINATE_AFTER': '2022-09-12'}, '2021-03-04', '2022-09-12',
-                              'STOP_AFTER', 'TERMINATE_AFTER'),
-                             ({'stopafter': '2022-05-10', 'terminateafter': '2022-05-11'}, '2022-05-10', '2022-05-11',
-                              'stopafter', 'terminateafter'),
-                             ({'StopAfter': '2030-07-23', 'TerminateAfter': '2050-08-10'}, '2030-07-23', '2050-08-10',
-                              'StopAfter', 'TerminateAfter'),
-                             ({'STOPAFTER': '2021-03-04', 'TERMINATEAFTER': '2022-09-12'}, '2021-03-04', '2022-09-12',
-                              'STOPAFTER', 'TERMINATEAFTER'),
-                             ({'': '2021-03-04', 'terminate.after': '2022-09-12'}, '', '2022-09-12', '',
-                              'terminate.after'),
-                             ({'stop.after': '2021-03-04', '': '2022-09-12'}, '2021-03-04', '', 'stop.after', '')
+@pytest.mark.parametrize('test_dict, expected_stop_result, expected_terminate_result, expected_nagbot_state, '
+                         'expected_stop_tag_name, expected_terminate_tag_name, expected_nagbot_state_tag_name', [
+                             ({'stop after': '2022-05-10', 'terminate after': '2022-05-11', 'nagbot state': 'running'},
+                              '2022-05-10', '2022-05-11', 'running', 'stop after', 'terminate after', 'nagbot state'),
+                             ({'Stop After': '2030-07-23', 'Terminate After': '2050-08-10', 'Nagbot State': 'running'},
+                              '2030-07-23', '2050-08-10', 'running', 'Stop After', 'Terminate After', 'Nagbot State'),
+                             ({'STOP AFTER': '2021-03-04', 'TERMINATE AFTER': '2022-09-12', 'NAGBOT STATE': 'running'},
+                              '2021-03-04', '2022-09-12', 'running', 'STOP AFTER', 'TERMINATE AFTER', 'NAGBOT STATE'),
+                             ({'stop_after': '2022-05-10', 'terminate_after': '2022-05-11', 'nagbot_state': 'running'},
+                              '2022-05-10', '2022-05-11', 'running', 'stop_after', 'terminate_after', 'nagbot_state'),
+                             ({'Stop_After': '2030-07-23', 'Terminate_After': '2050-08-10', 'Nagbot_State': 'running'},
+                              '2030-07-23', '2050-08-10', 'running', 'Stop_After', 'Terminate_After', 'Nagbot_State'),
+                             ({'STOP_AFTER': '2021-03-04', 'TERMINATE_AFTER': '2022-09-12', 'NAGBOT_STATE': 'running'},
+                              '2021-03-04', '2022-09-12', 'running', 'STOP_AFTER', 'TERMINATE_AFTER', 'NAGBOT_STATE'),
+                             ({'stopafter': '2022-05-10', 'terminateafter': '2022-05-11', 'nagbotstate': 'running'},
+                              '2022-05-10', '2022-05-11', 'running', 'stopafter', 'terminateafter', 'nagbotstate'),
+                             ({'StopAfter': '2030-07-23', 'TerminateAfter': '2050-08-10', 'NagbotState': 'running'},
+                              '2030-07-23', '2050-08-10', 'running', 'StopAfter', 'TerminateAfter', 'NagbotState'),
+                             ({'STOPAFTER': '2021-03-04', 'TERMINATEAFTER': '2022-09-12', 'NAGBOTSTATE': 'running'},
+                              '2021-03-04', '2022-09-12', 'running', 'STOPAFTER', 'TERMINATEAFTER', 'NAGBOTSTATE'),
+                             ({'': '2021-03-04', 'TerminateAfter': '2022-09-12', 'NagbotState': 'running'},
+                              '', '2022-09-12', 'running', 'StopAfter', 'TerminateAfter', 'NagbotState'),
+                             ({'StopAfter': '2021-03-04', '': '2022-09-12', 'NagbotState': 'running'},
+                              '2021-03-04', '', 'running', 'StopAfter', 'TerminateAfter', 'NagbotState'),
+                             ({'StopAfter': '2021-03-04', 'TerminateAfter': '2022-09-12', '': 'running'},
+                              '2021-03-04', '2022-09-12', '', 'StopAfter', 'TerminateAfter', 'NagbotState')
                          ])
-def test_stop_and_terminate_after(stop_terminate_dict, expected_stop_result,
-                                  expected_terminate_result, expected_stop_tag_name, expected_terminate_tag_name):
+def test_get_tag_names(test_dict, expected_stop_result, expected_terminate_result, expected_nagbot_state,
+                       expected_stop_tag_name, expected_terminate_tag_name, expected_nagbot_state_tag_name):
     stop_after_tag_name, terminate_after_tag_name, nagbot_state_tag_name = \
-        app.sqaws.get_tag_names(stop_terminate_dict)
-    stop_after = stop_terminate_dict.get(stop_after_tag_name, '')
-    terminate_after = stop_terminate_dict.get(terminate_after_tag_name, '')
+        app.sqaws.get_tag_names(test_dict)
+    stop_after = test_dict.get(stop_after_tag_name, '')
+    terminate_after = test_dict.get(terminate_after_tag_name, '')
+    nagbot_state = test_dict.get(nagbot_state_tag_name, '')
 
+    # Ensure tag value is correct
     assert stop_after == expected_stop_result
     assert terminate_after == expected_terminate_result
+    assert nagbot_state == expected_nagbot_state
 
     # Ensure tag name is set to default if empty string is passed in, otherwise should be the specified tag name
-    if expected_stop_tag_name == '':
-        assert stop_after_tag_name == 'StopAfter'
-    else:
-        assert stop_after_tag_name == expected_stop_tag_name
-    if expected_terminate_tag_name == '':
-        assert terminate_after_tag_name == 'TerminateAfter'
-    else:
-        assert terminate_after_tag_name == expected_terminate_tag_name
-    assert nagbot_state_tag_name == 'NagbotState'
+    assert stop_after_tag_name == expected_stop_tag_name
+    assert terminate_after_tag_name == expected_terminate_tag_name
+    assert nagbot_state_tag_name == expected_nagbot_state_tag_name

--- a/tests/test_sqaws.py
+++ b/tests/test_sqaws.py
@@ -96,5 +96,21 @@ def test_terminate_instance_exception(mock_client):
     mock_ec2.terminate_instances.assert_called_once_with(InstanceIds=[instance_id])
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.mark.parametrize('stop_terminate_dict, expected_stop_result, expected_terminate_result', [
+    ({'stop after': '2022-05-10', 'terminate after': '2022-05-11'}, '2022-05-10', '2022-05-11'),
+    ({'Stop After': '2030-07-23', 'Terminate After': '2050-08-10'}, '2030-07-23', '2050-08-10'),
+    ({'STOP AFTER': '2021-03-04', 'TERMINATE AFTER': '2022-09-12'}, '2021-03-04', '2022-09-12'),
+    ({'stop_after': '2022-05-10', 'terminate_after': '2022-05-11'}, '2022-05-10', '2022-05-11'),
+    ({'Stop_After': '2030-07-23', 'Terminate_After': '2050-08-10'}, '2030-07-23', '2050-08-10'),
+    ({'STOP_AFTER': '2021-03-04', 'TERMINATE_AFTER': '2022-09-12'}, '2021-03-04', '2022-09-12'),
+    ({'stopafter': '2022-05-10', 'terminateafter': '2022-05-11'}, '2022-05-10', '2022-05-11'),
+    ({'StopAfter': '2030-07-23', 'TerminateAfter': '2050-08-10'}, '2030-07-23', '2050-08-10'),
+    ({'STOPAFTER': '2021-03-04', 'TERMINATEAFTER': '2022-09-12'}, '2021-03-04', '2022-09-12'),
+    ({'': '2021-03-04', 'terminate.after': '2022-09-12'}, '', '2022-09-12'),
+    ({'stop.after': '2021-03-04', '': '2022-09-12'}, '2021-03-04', '')
+])
+def test_stop_and_terminate_after(stop_terminate_dict, expected_stop_result,
+                                  expected_terminate_result):
+    stop_terminate = app.sqaws.get_stop_and_terminate_after(stop_terminate_dict)
+    assert(stop_terminate[0] == expected_stop_result)
+    assert(stop_terminate[1] == expected_terminate_result)

--- a/tests/test_sqaws.py
+++ b/tests/test_sqaws.py
@@ -96,25 +96,5 @@ def test_terminate_instance_exception(mock_client):
     mock_ec2.terminate_instances.assert_called_once_with(InstanceIds=[instance_id])
 
 
-@pytest.mark.parametrize('stop_terminate_dict, expected_stop_result, expected_terminate_result', [
-    ({'stop after': '2022-05-10', 'terminate after': '2022-05-11'}, '2022-05-10', '2022-05-11'),
-    ({'Stop After': '2030-07-23', 'Terminate After': '2050-08-10'}, '2030-07-23', '2050-08-10'),
-    ({'STOP AFTER': '2021-03-04', 'TERMINATE AFTER': '2022-09-12'}, '2021-03-04', '2022-09-12'),
-    ({'stop_after': '2022-05-10', 'terminate_after': '2022-05-11'}, '2022-05-10', '2022-05-11'),
-    ({'Stop_After': '2030-07-23', 'Terminate_After': '2050-08-10'}, '2030-07-23', '2050-08-10'),
-    ({'STOP_AFTER': '2021-03-04', 'TERMINATE_AFTER': '2022-09-12'}, '2021-03-04', '2022-09-12'),
-    ({'stopafter': '2022-05-10', 'terminateafter': '2022-05-11'}, '2022-05-10', '2022-05-11'),
-    ({'StopAfter': '2030-07-23', 'TerminateAfter': '2050-08-10'}, '2030-07-23', '2050-08-10'),
-    ({'STOPAFTER': '2021-03-04', 'TERMINATEAFTER': '2022-09-12'}, '2021-03-04', '2022-09-12'),
-    ({'': '2021-03-04', 'terminate.after': '2022-09-12'}, '', '2022-09-12'),
-    ({'stop.after': '2021-03-04', '': '2022-09-12'}, '2021-03-04', '')
-])
-def test_stop_and_terminate_after(stop_terminate_dict, expected_stop_result,
-                                  expected_terminate_result):
-    stop_terminate = app.sqaws.get_stop_and_terminate_after(stop_terminate_dict)
-    assert(stop_terminate[0] == expected_stop_result)
-    assert(stop_terminate[1] == expected_terminate_result)
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_sqaws.py
+++ b/tests/test_sqaws.py
@@ -121,7 +121,8 @@ def test_terminate_instance_exception(mock_client):
                          ])
 def test_stop_and_terminate_after(stop_terminate_dict, expected_stop_result,
                                   expected_terminate_result, expected_stop_tag_name, expected_terminate_tag_name):
-    stop_after_tag_name, terminate_after_tag_name = app.sqaws.get_stop_and_terminate_after(stop_terminate_dict)
+    stop_after_tag_name, terminate_after_tag_name, nagbot_state_tag_name = \
+        app.sqaws.get_stop_and_terminate_after(stop_terminate_dict)
     stop_after = stop_terminate_dict.get(stop_after_tag_name, '')
     terminate_after = stop_terminate_dict.get(terminate_after_tag_name, '')
 
@@ -137,3 +138,4 @@ def test_stop_and_terminate_after(stop_terminate_dict, expected_stop_result,
         assert terminate_after_tag_name == 'TerminateAfter'
     else:
         assert terminate_after_tag_name == expected_terminate_tag_name
+    assert nagbot_state_tag_name == 'NagbotState'

--- a/tests/test_sqaws.py
+++ b/tests/test_sqaws.py
@@ -122,7 +122,7 @@ def test_terminate_instance_exception(mock_client):
 def test_stop_and_terminate_after(stop_terminate_dict, expected_stop_result,
                                   expected_terminate_result, expected_stop_tag_name, expected_terminate_tag_name):
     stop_after_tag_name, terminate_after_tag_name, nagbot_state_tag_name = \
-        app.sqaws.get_stop_and_terminate_after(stop_terminate_dict)
+        app.sqaws.get_tag_names(stop_terminate_dict)
     stop_after = stop_terminate_dict.get(stop_after_tag_name, '')
     terminate_after = stop_terminate_dict.get(terminate_after_tag_name, '')
 

--- a/tests/test_sqaws.py
+++ b/tests/test_sqaws.py
@@ -115,12 +115,12 @@ def test_terminate_instance_exception(mock_client):
                               '2030-07-23', '2050-08-10', 'running', 'StopAfter', 'TerminateAfter', 'NagbotState'),
                              ({'STOPAFTER': '2021-03-04', 'TERMINATEAFTER': '2022-09-12', 'NAGBOTSTATE': 'running'},
                               '2021-03-04', '2022-09-12', 'running', 'STOPAFTER', 'TERMINATEAFTER', 'NAGBOTSTATE'),
-                             ({'': '2021-03-04', 'TerminateAfter': '2022-09-12', 'NagbotState': 'running'},
-                              '', '2022-09-12', 'running', 'StopAfter', 'TerminateAfter', 'NagbotState'),
-                             ({'StopAfter': '2021-03-04', '': '2022-09-12', 'NagbotState': 'running'},
-                              '2021-03-04', '', 'running', 'StopAfter', 'TerminateAfter', 'NagbotState'),
-                             ({'StopAfter': '2021-03-04', 'TerminateAfter': '2022-09-12', '': 'running'},
-                              '2021-03-04', '2022-09-12', '', 'StopAfter', 'TerminateAfter', 'NagbotState')
+                             ({'TerminateAfter': '2022-09-12', 'NagbotState': 'running'}, '', '2022-09-12', 'running',
+                              'StopAfter', 'TerminateAfter', 'NagbotState'),
+                             ({'StopAfter': '2021-03-04', 'NagbotState': 'running'}, '2021-03-04', '', 'running',
+                              'StopAfter', 'TerminateAfter', 'NagbotState'),
+                             ({'StopAfter': '2021-03-04', 'TerminateAfter': '2022-09-12'}, '2021-03-04', '2022-09-12',
+                              '', 'StopAfter', 'TerminateAfter', 'NagbotState')
                          ])
 def test_get_tag_names(test_dict, expected_stop_result, expected_terminate_result, expected_nagbot_state,
                        expected_stop_tag_name, expected_terminate_tag_name, expected_nagbot_state_tag_name):

--- a/tests/test_sqaws.py
+++ b/tests/test_sqaws.py
@@ -96,21 +96,42 @@ def test_terminate_instance_exception(mock_client):
     mock_ec2.terminate_instances.assert_called_once_with(InstanceIds=[instance_id])
 
 
-@pytest.mark.parametrize('stop_terminate_dict, expected_stop_result, expected_terminate_result', [
-    ({'stop after': '2022-05-10', 'terminate after': '2022-05-11'}, '2022-05-10', '2022-05-11'),
-    ({'Stop After': '2030-07-23', 'Terminate After': '2050-08-10'}, '2030-07-23', '2050-08-10'),
-    ({'STOP AFTER': '2021-03-04', 'TERMINATE AFTER': '2022-09-12'}, '2021-03-04', '2022-09-12'),
-    ({'stop_after': '2022-05-10', 'terminate_after': '2022-05-11'}, '2022-05-10', '2022-05-11'),
-    ({'Stop_After': '2030-07-23', 'Terminate_After': '2050-08-10'}, '2030-07-23', '2050-08-10'),
-    ({'STOP_AFTER': '2021-03-04', 'TERMINATE_AFTER': '2022-09-12'}, '2021-03-04', '2022-09-12'),
-    ({'stopafter': '2022-05-10', 'terminateafter': '2022-05-11'}, '2022-05-10', '2022-05-11'),
-    ({'StopAfter': '2030-07-23', 'TerminateAfter': '2050-08-10'}, '2030-07-23', '2050-08-10'),
-    ({'STOPAFTER': '2021-03-04', 'TERMINATEAFTER': '2022-09-12'}, '2021-03-04', '2022-09-12'),
-    ({'': '2021-03-04', 'terminate.after': '2022-09-12'}, '', '2022-09-12'),
-    ({'stop.after': '2021-03-04', '': '2022-09-12'}, '2021-03-04', '')
-])
+@pytest.mark.parametrize('stop_terminate_dict, expected_stop_result, expected_terminate_result, '
+                         'expected_stop_str, expected_terminate_str', [
+                             ({'stop after': '2022-05-10', 'terminate after': '2022-05-11'}, '2022-05-10', '2022-05-11',
+                              'stop after', 'terminate after'),
+                             ({'Stop After': '2030-07-23', 'Terminate After': '2050-08-10'}, '2030-07-23', '2050-08-10',
+                              'Stop After', 'Terminate After'),
+                             ({'STOP AFTER': '2021-03-04', 'TERMINATE AFTER': '2022-09-12'}, '2021-03-04', '2022-09-12',
+                              'STOP AFTER', 'TERMINATE AFTER'),
+                             ({'stop_after': '2022-05-10', 'terminate_after': '2022-05-11'}, '2022-05-10', '2022-05-11',
+                              'stop_after', 'terminate_after'),
+                             ({'Stop_After': '2030-07-23', 'Terminate_After': '2050-08-10'}, '2030-07-23', '2050-08-10',
+                              'Stop_After', 'Terminate_After'),
+                             ({'STOP_AFTER': '2021-03-04', 'TERMINATE_AFTER': '2022-09-12'}, '2021-03-04', '2022-09-12',
+                              'STOP_AFTER', 'TERMINATE_AFTER'),
+                             ({'stopafter': '2022-05-10', 'terminateafter': '2022-05-11'}, '2022-05-10', '2022-05-11',
+                              'stopafter', 'terminateafter'),
+                             ({'StopAfter': '2030-07-23', 'TerminateAfter': '2050-08-10'}, '2030-07-23', '2050-08-10',
+                              'StopAfter', 'TerminateAfter'),
+                             ({'STOPAFTER': '2021-03-04', 'TERMINATEAFTER': '2022-09-12'}, '2021-03-04', '2022-09-12',
+                              'STOPAFTER', 'TERMINATEAFTER'),
+                             ({'': '2021-03-04', 'terminate.after': '2022-09-12'}, '', '2022-09-12', '',
+                              'terminate.after'),
+                             ({'stop.after': '2021-03-04', '': '2022-09-12'}, '2021-03-04', '', 'stop.after', '')
+                         ])
 def test_stop_and_terminate_after(stop_terminate_dict, expected_stop_result,
-                                  expected_terminate_result):
-    stop_terminate = app.sqaws.get_stop_and_terminate_after(stop_terminate_dict)
-    assert(stop_terminate[0] == expected_stop_result)
-    assert(stop_terminate[1] == expected_terminate_result)
+                                  expected_terminate_result, expected_stop_str, expected_terminate_str):
+    stop_after_str, terminate_after_str = app.sqaws.get_stop_and_terminate_after(stop_terminate_dict)
+    if stop_after_str == '':
+        stop_after = ''
+    else:
+        stop_after = stop_terminate_dict.get(stop_after_str)
+    if terminate_after_str == '':
+        terminate_after = ''
+    else:
+        terminate_after = stop_terminate_dict.get(terminate_after_str)
+    assert (stop_after == expected_stop_result)
+    assert (terminate_after == expected_terminate_result)
+    assert (stop_after_str == expected_stop_str)
+    assert (terminate_after_str == expected_terminate_str)

--- a/tests/test_sqaws.py
+++ b/tests/test_sqaws.py
@@ -3,91 +3,117 @@ from unittest.mock import patch
 
 import app.sqaws
 
+import pytest
 
-class TestAws(unittest.TestCase):
-    def test_make_tags_dict(self):
-        tags_list = [{'Key': 'Contact', 'Value': 'stephen.rosenthal@seeq.com'},
-                     {'Key': 'Stop after', 'Value': '2020-01-01'},
-                     {'Key': 'Terminate after', 'Value': '2021-01-01'},
-                     {'Key': 'Name', 'Value': 'super-cool-server.seeq.com'}]
 
-        tags_dict = app.sqaws.make_tags_dict(tags_list)
+def test_make_tags_dict():
+    tags_list = [{'Key': 'Contact', 'Value': 'stephen.rosenthal@seeq.com'},
+                 {'Key': 'Stop after', 'Value': '2020-01-01'},
+                 {'Key': 'Terminate after', 'Value': '2021-01-01'},
+                 {'Key': 'Name', 'Value': 'super-cool-server.seeq.com'}]
 
-        assert tags_dict == {'Contact': 'stephen.rosenthal@seeq.com',
-                             'Stop after': '2020-01-01',
-                             'Terminate after': '2021-01-01',
-                             'Name': 'super-cool-server.seeq.com'}
+    tags_dict = app.sqaws.make_tags_dict(tags_list)
 
-    @patch('app.sqaws.boto3.client')
-    def test_set_tag(self, mock_client):
-        region_name = 'us-east-1'
-        instance_id = 'i-0f06b49c1f16dcfde'
-        tag_name = 'Stop after'
-        tag_value = '2019-12-25'
-        mock_ec2 = mock_client.return_value
+    assert tags_dict == {'Contact': 'stephen.rosenthal@seeq.com',
+                         'Stop after': '2020-01-01',
+                         'Terminate after': '2021-01-01',
+                         'Name': 'super-cool-server.seeq.com'}
 
-        app.sqaws.set_tag(region_name, instance_id, tag_name, tag_value, dryrun=False)
 
-        mock_client.assert_called_once_with('ec2', region_name=region_name)
-        mock_ec2.create_tags.assert_called_once_with(Resources=[instance_id], Tags=[{
-            'Key': tag_name,
-            'Value': tag_value
-        }])
+@patch('app.sqaws.boto3.client')
+def test_set_tag(mock_client):
+    region_name = 'us-east-1'
+    instance_id = 'i-0f06b49c1f16dcfde'
+    tag_name = 'Stop after'
+    tag_value = '2019-12-25'
+    mock_ec2 = mock_client.return_value
 
-    @patch('app.sqaws.boto3.client')
-    def test_stop_instance(self, mock_client):
-        region_name = 'us-east-1'
-        instance_id = 'i-0f06b49c1f16dcfde'
-        mock_ec2 = mock_client.return_value
+    app.sqaws.set_tag(region_name, instance_id, tag_name, tag_value, dryrun=False)
 
-        assert app.sqaws.stop_instance(region_name, instance_id, dryrun=False)
+    mock_client.assert_called_once_with('ec2', region_name=region_name)
+    mock_ec2.create_tags.assert_called_once_with(Resources=[instance_id], Tags=[{
+        'Key': tag_name,
+        'Value': tag_value
+    }])
 
-        mock_client.assert_called_once_with('ec2', region_name=region_name)
-        mock_ec2.stop_instances.assert_called_once_with(InstanceIds=[instance_id])
 
-    @patch('app.sqaws.boto3.client')
-    def test_stop_instance_exception(self, mock_client):
-        # Note: I haven't seen the call to stop_instance fail, but it certainly could.
-        def raise_error():
-            raise RuntimeError('An error occurred (OperationNotPermitted)...')
+@patch('app.sqaws.boto3.client')
+def test_stop_instance(mock_client):
+    region_name = 'us-east-1'
+    instance_id = 'i-0f06b49c1f16dcfde'
+    mock_ec2 = mock_client.return_value
 
-        region_name = 'us-east-1'
-        instance_id = 'i-0f06b49c1f16dcfde'
-        mock_ec2 = mock_client.return_value
-        mock_ec2.stop_instances.side_effect = lambda *args, **kw: raise_error()
+    assert app.sqaws.stop_instance(region_name, instance_id, dryrun=False)
 
-        assert not app.sqaws.stop_instance(region_name, instance_id, dryrun=False)
+    mock_client.assert_called_once_with('ec2', region_name=region_name)
+    mock_ec2.stop_instances.assert_called_once_with(InstanceIds=[instance_id])
 
-        mock_client.assert_called_once_with('ec2', region_name=region_name)
-        mock_ec2.stop_instances.assert_called_once_with(InstanceIds=[instance_id])
 
-    @patch('app.sqaws.boto3.client')
-    def test_terminate_instance(self, mock_client):
-        region_name = 'us-east-1'
-        instance_id = 'i-0f06b49c1f16dcfde'
-        mock_ec2 = mock_client.return_value
+@patch('app.sqaws.boto3.client')
+def test_stop_instance_exception(mock_client):
+    # Note: I haven't seen the call to stop_instance fail, but it certainly could.
+    def raise_error():
+        raise RuntimeError('An error occurred (OperationNotPermitted)...')
 
-        assert app.sqaws.terminate_instance(region_name, instance_id, dryrun=False)
+    region_name = 'us-east-1'
+    instance_id = 'i-0f06b49c1f16dcfde'
+    mock_ec2 = mock_client.return_value
+    mock_ec2.stop_instances.side_effect = lambda *args, **kw: raise_error()
 
-        mock_client.assert_called_once_with('ec2', region_name=region_name)
-        mock_ec2.terminate_instances.assert_called_once_with(InstanceIds=[instance_id])
+    assert not app.sqaws.stop_instance(region_name, instance_id, dryrun=False)
 
-    @patch('app.sqaws.boto3.client')
-    def test_terminate_instance_exception(self, mock_client):
-        # Note: I've seen the call to terminate_instance fail when termination protection is enabled
-        def raise_error():
-            # The real Boto SDK raises botocore.exceptions.ClientError, but this is close enough
-            raise RuntimeError('An error occurred (OperationNotPermitted)...')
+    mock_client.assert_called_once_with('ec2', region_name=region_name)
+    mock_ec2.stop_instances.assert_called_once_with(InstanceIds=[instance_id])
 
-        region_name = 'us-east-1'
-        instance_id = 'i-0f06b49c1f16dcfde'
-        mock_ec2 = mock_client.return_value
-        mock_ec2.terminate_instances.side_effect = lambda *args, **kw: raise_error()
 
-        assert not app.sqaws.terminate_instance(region_name, instance_id, dryrun=False)
+@patch('app.sqaws.boto3.client')
+def test_terminate_instance(mock_client):
+    region_name = 'us-east-1'
+    instance_id = 'i-0f06b49c1f16dcfde'
+    mock_ec2 = mock_client.return_value
 
-        mock_client.assert_called_once_with('ec2', region_name=region_name)
-        mock_ec2.terminate_instances.assert_called_once_with(InstanceIds=[instance_id])
+    assert app.sqaws.terminate_instance(region_name, instance_id, dryrun=False)
+
+    mock_client.assert_called_once_with('ec2', region_name=region_name)
+    mock_ec2.terminate_instances.assert_called_once_with(InstanceIds=[instance_id])
+
+
+@patch('app.sqaws.boto3.client')
+def test_terminate_instance_exception(mock_client):
+    # Note: I've seen the call to terminate_instance fail when termination protection is enabled
+    def raise_error():
+        # The real Boto SDK raises botocore.exceptions.ClientError, but this is close enough
+        raise RuntimeError('An error occurred (OperationNotPermitted)...')
+
+    region_name = 'us-east-1'
+    instance_id = 'i-0f06b49c1f16dcfde'
+    mock_ec2 = mock_client.return_value
+    mock_ec2.terminate_instances.side_effect = lambda *args, **kw: raise_error()
+
+    assert not app.sqaws.terminate_instance(region_name, instance_id, dryrun=False)
+
+    mock_client.assert_called_once_with('ec2', region_name=region_name)
+    mock_ec2.terminate_instances.assert_called_once_with(InstanceIds=[instance_id])
+
+
+@pytest.mark.parametrize('stop_terminate_dict, expected_stop_result, expected_terminate_result', [
+    ({'stop after': '2022-05-10', 'terminate after': '2022-05-11'}, '2022-05-10', '2022-05-11'),
+    ({'Stop After': '2030-07-23', 'Terminate After': '2050-08-10'}, '2030-07-23', '2050-08-10'),
+    ({'STOP AFTER': '2021-03-04', 'TERMINATE AFTER': '2022-09-12'}, '2021-03-04', '2022-09-12'),
+    ({'stop_after': '2022-05-10', 'terminate_after': '2022-05-11'}, '2022-05-10', '2022-05-11'),
+    ({'Stop_After': '2030-07-23', 'Terminate_After': '2050-08-10'}, '2030-07-23', '2050-08-10'),
+    ({'STOP_AFTER': '2021-03-04', 'TERMINATE_AFTER': '2022-09-12'}, '2021-03-04', '2022-09-12'),
+    ({'stopafter': '2022-05-10', 'terminateafter': '2022-05-11'}, '2022-05-10', '2022-05-11'),
+    ({'StopAfter': '2030-07-23', 'TerminateAfter': '2050-08-10'}, '2030-07-23', '2050-08-10'),
+    ({'STOPAFTER': '2021-03-04', 'TERMINATEAFTER': '2022-09-12'}, '2021-03-04', '2022-09-12'),
+    ({'': '2021-03-04', 'terminate.after': '2022-09-12'}, '', '2022-09-12'),
+    ({'stop.after': '2021-03-04', '': '2022-09-12'}, '2021-03-04', '')
+])
+def test_stop_and_terminate_after(stop_terminate_dict, expected_stop_result,
+                                  expected_terminate_result):
+    stop_terminate = app.sqaws.get_stop_and_terminate_after(stop_terminate_dict)
+    assert(stop_terminate[0] == expected_stop_result)
+    assert(stop_terminate[1] == expected_terminate_result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added support for tags without spaces per AWS update: https://derflounder.wordpress.com/2022/01/11/amazon-web-servicess-new-ec2-metadata-tag-option-doesnt-allow-spaces-in-tag-names/