### PR TITLE
CRAB-29308: stop instances without stop after tag without warning

### DIFF
--- a/app/instance.py
+++ b/app/instance.py
@@ -135,8 +135,8 @@ class Instance(Resource):
             print(f'Failure when calling terminate_instances: {str(e)}')
             return False
 
-    def is_stoppable_without_warning(self):
-        return self.generic_is_stoppable_without_warning(self)
+    def is_stoppable_without_warning(self,is_weekend=TODAY_IS_WEEKEND):
+        return self.generic_is_stoppable_without_warning(self, is_weekend)
 
     # Check if an instance is stoppable
     def is_stoppable(self, today_date, is_weekend=TODAY_IS_WEEKEND):

--- a/app/instance.py
+++ b/app/instance.py
@@ -135,6 +135,9 @@ class Instance(Resource):
             print(f'Failure when calling terminate_instances: {str(e)}')
             return False
 
+    def is_stoppable_without_warning(self):
+        return self.generic_is_stoppable_without_warning(self)
+
     # Check if an instance is stoppable
     def is_stoppable(self, today_date, is_weekend=TODAY_IS_WEEKEND):
         return self.generic_is_stoppable(self, today_date, is_weekend)

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -102,9 +102,10 @@ class Nagbot(object):
             resources_to_terminate = list(r for r in resources if r.is_terminatable(TODAY_YYYY_MM_DD) and
                                           r.is_safe_to_terminate(TODAY_YYYY_MM_DD))
 
-            # Only stop resources which still meet the criteria for stopping, AND were warned recently
-            resources_to_stop = list(r for r in resources if r.is_stoppable(today_date=TODAY_YYYY_MM_DD)
-                                     and r.is_safe_to_stop(today_date=TODAY_YYYY_MM_DD))
+            # Only stop resources which still meet the criteria for stopping
+            resources_to_stop = list(r for r in resources if (r.is_stoppable_without_warning()) or
+                                     (r.is_stoppable(today_date=TODAY_YYYY_MM_DD)
+                                      and r.is_safe_to_stop(today_date=TODAY_YYYY_MM_DD)))
 
             if len(resources_to_terminate) > 0:
                 message = 'I terminated the following {}s: '.format(ec2_type)

--- a/app/resource.py
+++ b/app/resource.py
@@ -154,6 +154,11 @@ class Resource:
                         iops=iops,
                         throughput=throughput)
 
+    # Instance should be stopped without warning
+    @staticmethod
+    def generic_is_stoppable_without_warning(resource):
+        return resource.ec2_type == 'instance' and resource.stop_after == '' and resource.state == 'stopped'
+
     # Check if a resource is stoppable - currently, only instances should be stoppable
     @staticmethod
     def generic_is_stoppable(resource, today_date, is_weekend=TODAY_IS_WEEKEND):

--- a/app/resource.py
+++ b/app/resource.py
@@ -156,8 +156,13 @@ class Resource:
 
     # Instance should be stopped without warning
     @staticmethod
-    def generic_is_stoppable_without_warning(resource):
-        return resource.ec2_type == 'instance' and resource.stop_after == '' and resource.state == 'stopped'
+    def generic_is_stoppable_without_warning(resource, is_weekend=TODAY_IS_WEEKEND):
+        if not resource.ec2_type == 'instance':
+            return False
+        parsed_date: parsing.ParsedDate = parsing.parse_date_tag(resource.stop_after)
+        return resource.state == 'running' and \
+            (parsed_date.expiry_date is None and not parsed_date.on_weekends) or \
+            (parsed_date.expiry_date is None and parsed_date.on_weekends and is_weekend)
 
     # Check if a resource is stoppable - currently, only instances should be stoppable
     @staticmethod

--- a/app/resource.py
+++ b/app/resource.py
@@ -154,15 +154,14 @@ class Resource:
                         iops=iops,
                         throughput=throughput)
 
-    # Instance should be stopped without warning
+    # Instance with no "stop after" date should be stopped without warning
     @staticmethod
     def generic_is_stoppable_without_warning(resource, is_weekend=TODAY_IS_WEEKEND):
         if not resource.ec2_type == 'instance':
             return False
         parsed_date: parsing.ParsedDate = parsing.parse_date_tag(resource.stop_after)
-        return resource.state == 'running' and \
-            (parsed_date.expiry_date is None and not parsed_date.on_weekends) or \
-            (parsed_date.expiry_date is None and parsed_date.on_weekends and is_weekend)
+        return resource.state == 'running' and parsed_date.expiry_date is None and \
+            ((not parsed_date.on_weekends) or (parsed_date.on_weekends and is_weekend))
 
     # Check if a resource is stoppable - currently, only instances should be stoppable
     @staticmethod

--- a/app/volume.py
+++ b/app/volume.py
@@ -124,6 +124,9 @@ class Volume(Resource):
             print(f'Failure when calling delete_volumes: {str(e)}')
             return False
 
+    def is_stoppable_without_warning(self):
+        return self.generic_is_stoppable_without_warning(self)
+
     # Check if a volume is stoppable (should always be false)
     def is_stoppable(self, today_date, is_weekend=TODAY_IS_WEEKEND):
         return self.generic_is_stoppable(self, today_date, is_weekend)

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -33,6 +33,15 @@ class TestInstance(unittest.TestCase):
                         iops=0,
                         throughput=0)
 
+    def test_stoppable_without_warning(self):
+        running_no_stop_after = self.setup_instance(state='running')
+        stopped_no_stop_after = self.setup_instance(state='stopped')
+        past_date = self.setup_instance(state='running', stop_after='2019-01-01')
+
+        assert Instance.is_stoppable_without_warning(running_no_stop_after) is False
+        assert Instance.is_stoppable_without_warning(stopped_no_stop_after) is True
+        assert Instance.is_stoppable_without_warning(past_date) is False
+
     def test_stoppable(self):
         past_date = self.setup_instance(state='running', stop_after='2019-01-01')
         today_date = self.setup_instance(state='running', stop_after=nagbot.TODAY_YYYY_MM_DD)

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -37,10 +37,17 @@ class TestInstance(unittest.TestCase):
         running_no_stop_after = self.setup_instance(state='running')
         stopped_no_stop_after = self.setup_instance(state='stopped')
         past_date = self.setup_instance(state='running', stop_after='2019-01-01')
+        notified = self.setup_instance(state='running', stop_after='(Nagbot: Warned on 2022-10-14)')
+        weekend = self.setup_instance(state='running', stop_after='On Weekends')
 
-        assert Instance.is_stoppable_without_warning(running_no_stop_after) is False
-        assert Instance.is_stoppable_without_warning(stopped_no_stop_after) is True
+        assert Instance.is_stoppable_without_warning(running_no_stop_after) is True
+        assert Instance.is_stoppable_without_warning(stopped_no_stop_after) is False
         assert Instance.is_stoppable_without_warning(past_date) is False
+        assert Instance.is_stoppable_without_warning(notified) is True
+        # During weekdays do not delete instance with stop after tag "On Weekend"
+        assert Instance.is_stoppable_without_warning(weekend, is_weekend=False) is False
+        # On Weekend delete instance with stop after tag "On Weekend"
+        assert Instance.is_stoppable_without_warning(weekend, is_weekend=True) is True
 
     def test_stoppable(self):
         past_date = self.setup_instance(state='running', stop_after='2019-01-01')

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -32,6 +32,13 @@ class TestVolume(unittest.TestCase):
                       iops=1,
                       throughput=125)
 
+    def test_stoppable_without_warning(self):
+        running_no_stop_after = self.setup_volume(state='running')
+        stopped_no_stop_after = self.setup_volume(state='stopped')
+
+        assert Volume.is_stoppable_without_warning(running_no_stop_after) is False
+        assert Volume.is_stoppable_without_warning(stopped_no_stop_after) is False
+
     def test_stoppable(self):
         todays_date = nagbot.TODAY_YYYY_MM_DD
         past_date = self.setup_volume(state='available', terminate_after='2019-01-01')


### PR DESCRIPTION
Description: Instances that do not have a "stop after" tag should be stopped immediately without giving any warnings. 

Takeaways:
1. Nagbot runs in the morning with `notify` mode in the morning and terminates/stops the instances in the evening. 
2. Current implementation does not stop instances with just `On Weekends` tag. Those need to be warned too. This PR will remove such instances also. 