### PR TITLE
CRAB-30367: Use pacific time zone

### DIFF
--- a/app/resource.py
+++ b/app/resource.py
@@ -3,9 +3,11 @@ from dataclasses import dataclass
 import boto3
 from datetime import datetime, timedelta
 
+import pytz as pytz
+
 from . import parsing
 
-TODAY = datetime.today()
+TODAY = datetime.now(pytz.timezone('US/Pacific'))
 TODAY_IS_WEEKEND = TODAY.weekday() >= 4  # Days are 0-6. 4=Friday, 5=Saturday, 6=Sunday, 0=Monday
 MIN_TERMINATION_WARNING_YYYY_MM_DD = (TODAY - timedelta(days=3)).strftime('%Y-%m-%d')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto3==1.20.26
 slackclient==2.9.3
 pygsheets==2.0.5
 pytest==7.1.2
+pytz==2022.4


### PR DESCRIPTION
Description of the bug: Nagbot stops the instances with "Stop After": "On Weekends (warned: {date})" on Thursday instead of Friday. 
RCA: The reason is Nagbot app runs in the UTC time zone and at the time of the second run of the bot the date in UTC has advanced to the next day. So the instances are stopped early on Thursday. The same reason can be applied to Termination days. 
Fix: With this PR, Nagbot will consider the Pacific time zone instead of UTC.
 