### PR TITLE
CRAB-33767: Incorporate Snapshots and AMIs in NagBot

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Keeper [here]
 (https://keepersecurity.
 com/vault/#detail/AUj3FYXz44uON4CVQSTKMQ).
 
-# Releasing New Versions
+# Releasing New Versions (Seeq Employees)
 
 Update the version at the top of nagbot.py to vX.Y.Z, commit, and push your changes
 
@@ -57,8 +57,12 @@ Promote to `prod` using:
 jfrog rt docker-promote nagbot nagbot-docker-dev-local nagbot-docker-prod-local --copy=true --source-tag=vX.Y.Z
 ```
 
-Apply the newly created 'prod' image's tag to the NagBot Job in the build infra cluster by updating the devops repo at
-`devops/devops/build-infra-cluster/nagbot/jobs.yaml`, then applying the changes with 
+Next, apply the newly created 'prod' image's tag to the NagBot Job in the build infra cluster. To do this, check out 
+the [devops](https://github.com/seeq12/devops) repo, create a new branch, then update the docker tag in
+`devops/devops/build-infra-cluster/nagbot/jobs.yaml`. After connecting to the build infra cluster by following 
+instructions in [How to Access the Build Infra Cluster](https://seeq.atlassian.
+net/wiki/spaces/SQ/pages/2317386552/How+to+Access+the+Dev-Infra+Cluster), apply the changes using: 
 ```sh
 kubectl apply -f devops/devops/build-infra-cluster/nagbot/jobs.yaml
 ```
+Finally, create a PR with the updated version.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ Here's what a Nagbot notification looks like in Slack:
 
 Here is a [recording of the process to setup a Slack app](https://seeq.zoom.us/rec/share/qgmqAvz_2eV3SYiNJO4mLrQlH94eGXSs89BDSl28Epl-Bjey9_DgvBLnkF3W2dOf.Zd12Sq-G5QbsOPrt) (Passcode: z?mJ%d08). The process frequently changes due to Slack changing the UI for applications.
 
+# Testing Nagbot changes during development
+
+The NagBotTest app has been registered to slack, and it is set up to send NagBot output to slack. The default 
+testing channel for NagBot is #bot-testing. 
+
+The SLACK_BOT_TOKEN for NagBotTest is found on Keeper [here](https://keepersecurity.com/vault/#detail/AUj3FYXz44uON4CVQSTKMQ).
+
 # Releasing New Versions
 
 Update the version at the top of nagbot.py to vX.Y.Z, commit, and push your changes

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ Here is a [recording of the process to setup a Slack app](https://seeq.zoom.us/r
 The NagBotTest app has been registered to slack, and it is set up to send NagBot output to slack. The default 
 testing channel for NagBot is #bot-testing. 
 
-The SLACK_BOT_TOKEN for NagBotTest is found on Keeper [here](https://keepersecurity.com/vault/#detail/AUj3FYXz44uON4CVQSTKMQ).
+For Seeq employees looking to test changes to NagBot during development, the SLACK_BOT_TOKEN for NagBotTest is found on 
+Keeper [here]
+(https://keepersecurity.
+com/vault/#detail/AUj3FYXz44uON4CVQSTKMQ).
 
 # Releasing New Versions
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ At Seeq, we launch a lot of EC2 instances for a variety of development purposes 
 Nagbot is a side project I developed at [Seeq](https://seeq.com) and launched in May 2019. It has saved thousands of dollars every month, probably tens of thousands in the few months it has been running so far.
 
 Nagbot does the following:
-1. Query for all of the running EC2 instances in an account, along with important metadata (Name, OS, Monthly Price, etc.)
+1. Query for all EC2 Instances, Volumes, AMIs, and Snapshots in an account, along 
+   with important metadata (Name, OS, Monthly Price, size, etc.)
 2. Post this information to a Slack channel and also dump the table into a Google Sheet for analysis and auditing
-3. Look at the "Stop after" tag, which is by convention a YYYY-MM-DD date, and after a warning period, stop any unwanted instances.
+3. Look at the "Stop after" tag, which is by convention a YYYY-MM-DD date, and after a warning period, stop any 
+   unwanted resources.
+4. Look at the "Terminate after" tag, which is by convention a YYYY-MM-DD date, and terminate any unwanted resources.
 
 Here's what a Nagbot notification looks like in Slack:
 ![Example of Nagbot's Slack message](https://github.com/srosenthal/nagbot/blob/master/nagbot-slack.png "Example of Nagbot's Slack message")
@@ -36,8 +39,16 @@ git push --tags
 
 Wait for GitHub Actions to publish the new tag to [JFrog](https://seeq.jfrog.io/ui/packages/docker:%2F%2Fnagbot)
 
+For access to JFrog, see the [JFrog Confluence Page](https://seeq.atlassian.net/wiki/spaces/SQ/pages/2266562701/JFrog)
+
 Promote to `prod` using:
 
 ```sh
 jfrog rt docker-promote nagbot nagbot-docker-dev-local nagbot-docker-prod-local --copy=true --source-tag=vX.Y.Z
+```
+
+Apply the newly created 'prod' image's tag to the NagBot Job in the build infra cluster by updating the devops repo at
+`devops/devops/build-infra-cluster/nagbot/jobs.yaml`, then applying the changes with 
+```sh
+kubectl apply -f devops/devops/build-infra-cluster/nagbot/jobs.yaml
 ```

--- a/app/ami.py
+++ b/app/ami.py
@@ -23,57 +23,50 @@ TODAY_IS_WEEKEND = TODAY.weekday() >= 4  # Days are 0-6. 4=Friday, 5=Saturday, 6
 class Ami(Resource):
     state: str
     ec2_type: str
-    # monthly_price: float
-    # monthly_server_price: float
-    # monthly_storage_price: float
-    # size: float
+    monthly_price: float
 
-    # Return the type and state of the EC2 resource being examined ('volume' and 'unattached')
+    # Return the type and state of the EC2 resource being examined ('ami' and 'available')
     @staticmethod
     def to_string():
-        return 'volume', 'unattached'
+        return 'ami', 'available'
 
-    # @staticmethod
-    # def to_header() -> [str]:
-    #     return ['Volume ID',
-    #             'Name',
-    #             'State',
-    #             'Terminate After',
-    #             'Contact',
-    #             'Monthly Price',
-    #             'Region Name',
-    #             'Volume Type',
-    #             'OS'
-    #             'Size',
-    #             'IOPS',
-    #             'Throughput']
-    #
-    # def to_list(self) -> [str]:
-    #     return [self.resource_id,
-    #             self.name,
-    #             self.state,
-    #             self.terminate_after,
-    #             self.contact,
-    #             self.monthly_price,
-    #             self.region_name,
-    #             self.resource_type,
-    #             self.operating_system,
-    #             self.size,
-    #             self.iops,
-    #             self.throughput]
+    @staticmethod
+    def to_header() -> [str]:
+        return ['AMI ID',
+                'Name',
+                'State',
+                'Terminate After',
+                'Contact',
+                'Monthly Price',
+                'Region Name',
+                'Volume Type',
+                'OS'
+                'IOPS',
+                'Throughput']
 
-    # Get a list of model classes representing important properties of EBS volumes
+    def to_list(self) -> [str]:
+        return [self.resource_id,
+                self.name,
+                self.state,
+                self.terminate_after,
+                self.contact,
+                self.monthly_price,
+                self.region_name,
+                self.resource_type,
+                self.operating_system,
+                self.iops,
+                self.throughput]
+
+    # Get a list of model classes representing important properties of AMIs
     @staticmethod
     def list_resources():
         describe_regions_response = Resource.generic_list_resources()
-        # print(describe_regions_response)
 
         amis = []
 
         for region in describe_regions_response['Regions']:
             region_name = region['RegionName']
             ec2 = boto3.client('ec2', region_name=region_name)
-            # TODO: does self work for aws subaccount? Or does that ID need to be explicitly included?
             describe_images_response = ec2.describe_images(Owners=['self'])
 
             for ami_dict in describe_images_response['Images']:
@@ -88,20 +81,16 @@ class Ami(Resource):
 
         state = resource_dict['State']
         ec2_type = 'ami'
-        # size = resource_dict['Size']  no size included for ami
 
         resource_id_tag = 'ImageId'
         resource_type_tag = 'ImageType'
+        name = resource_dict[resource_id_tag]
         ami = Resource.build_generic_model(tags, resource_dict, region_name, resource_id_tag, resource_type_tag)
+        ami_type = resource_dict['RootDeviceType']  # either instance-store or ebs
+        block_device_mappings = resource_dict['BlockDeviceMappings']  # the collection of ebs snapshots forming the ami
 
-        # TODO: estimate monthly cost of ami
-        # monthly_price = resource.estimate_monthly_ami_price(region_name, ami.resource_id,
-        #                                                             ami.resource_type, size, ami.iops,
-        #                                                             ami.throughput)
-        # print(monthly_price)
-        # print()
-        # print(ami)
-        # monthly_server_price, monthly_storage_price = 0, 0
+        monthly_price = resource.estimate_monthly_ami_price(ami_type, block_device_mappings, name)
+        print(monthly_price)
 
         return Ami(region_name=region_name,
                       resource_id=ami.resource_id,
@@ -112,9 +101,7 @@ class Ami(Resource):
                       eks_nodegroup_name=ami.eks_nodegroup_name,
                       name=ami.name,
                       operating_system=ami.operating_system,
-                      # monthly_price=monthly_price,
-                      # monthly_server_price=monthly_server_price,
-                      # monthly_storage_price=monthly_storage_price,
+                      monthly_price=monthly_price,
                       stop_after=ami.stop_after,
                       terminate_after=ami.terminate_after,
                       nagbot_state=ami.nagbot_state,
@@ -122,58 +109,61 @@ class Ami(Resource):
                       stop_after_tag_name=ami.stop_after_tag_name,
                       terminate_after_tag_name=ami.terminate_after_tag_name,
                       nagbot_state_tag_name=ami.nagbot_state_tag_name,
-                      # size=size,
                       iops=ami.iops,
                       throughput=ami.throughput)
-    #
-    # # Delete/terminate an EBS volume
-    # def terminate_resource(self, dryrun: bool) -> bool:
-    #     print(f'Deleting volume: {str(self.resource_id)}...')
-    #     ec2 = boto3.client('ec2', region_name=self.region_name)
-    #     try:
-    #         if not dryrun:
-    #             response = ec2.delete_volume(VolumeId=self.resource_id)
-    #             print(f'Response from delete_volumes: {str(response)}')
-    #         return True
-    #     except Exception as e:
-    #         print(f'Failure when calling delete_volumes: {str(e)}')
-    #         return False
-    #
-    # # Check if a volume is stoppable (should always be false)
-    # def is_stoppable(self, today_date, is_weekend=TODAY_IS_WEEKEND):
-    #     return self.generic_is_stoppable(self, today_date, is_weekend)
-    #
-    # # Check if a volume is deletable/terminatable
-    # def is_terminatable(self, today_date):
-    #     state = 'available'
-    #     return self.generic_is_terminatable(self, state, today_date)
-    #
-    # # Check if a volume is safe to stop (should always be false)
-    # def is_safe_to_stop(self, today_date, is_weekend=TODAY_IS_WEEKEND):
-    #     return self.generic_is_safe_to_stop(self, today_date, is_weekend)
-    #
-    # # Check if a volume is safe to delete/terminate
-    # def is_safe_to_terminate(self, today_date):
-    #     resource_type = Volume
-    #     return self.generic_is_safe_to_terminate(self, resource_type, today_date)
-    #
-    # # Create volume summary
-    # def make_resource_summary(self):
-    #     resource_type = Volume
-    #     link = self.make_generic_resource_summary(self, resource_type)
-    #     state = f'State={self.state}'
-    #     line = '{link}, {state}, Type={self.resource_type}'
-    #     return line
-    #
-    # # Create volume url
-    # @staticmethod
-    # def url_from_id(region_name, resource_id):
-    #     resource_type = 'Volumes'
-    #     return Resource.generic_url_from_id(region_name, resource_id, resource_type)
-    #
-    # # Include volume in monthly price calculation if available
-    # def included_in_monthly_price(self):
-    #     if self.state == 'available':
-    #         return True
-    #     else:
-    #         return False
+
+    # Delete/terminate an AMI
+    def terminate_resource(self, dryrun: bool) -> bool:
+        print(f'Deleting volume: {str(self.resource_id)}...')
+        ec2 = boto3.resource('ec2', region_name=self.region_name)
+        image = ec2.Image(self.resource_id)
+        try:
+            if not dryrun:
+                response = image.deregister()  # response should return None
+                print(f'Response from delete_volumes: {str(response)}')
+            return True
+        except Exception as e:
+            print(f'Failure when calling delete_volumes: {str(e)}')
+            return False
+
+    def is_stoppable_without_warning(self):
+        return self.generic_is_stoppable_without_warning(self)
+
+    # Check if an ami is stoppable (should always be false)
+    def is_stoppable(self, today_date, is_weekend=TODAY_IS_WEEKEND):
+        return self.generic_is_stoppable(self, today_date, is_weekend)
+
+    # Check if an ami is deletable/terminatable
+    def is_terminatable(self, today_date):
+        state = 'available'
+        return self.generic_is_terminatable(self, state, today_date)
+
+    # Check if an ami is safe to stop (should always be false)
+    def is_safe_to_stop(self, today_date, is_weekend=TODAY_IS_WEEKEND):
+        return self.generic_is_safe_to_stop(self, today_date, is_weekend)
+
+    # Check if an ami is safe to delete/terminate
+    def is_safe_to_terminate(self, today_date):
+        resource_type = Ami
+        return self.generic_is_safe_to_terminate(self, resource_type, today_date)
+
+    # Create ami summary
+    def make_resource_summary(self):
+        resource_type = Ami
+        link = self.make_generic_resource_summary(self, resource_type)
+        state = f'State={self.state}'
+        line = f'{link}, {state}, Type={self.resource_type}'
+        return line
+
+    # Create ami url
+    @staticmethod
+    def url_from_id(region_name, resource_id):
+        resource_type = 'Amis'
+        return Resource.generic_url_from_id(region_name, resource_id, resource_type)
+
+    # Include ami in monthly price calculation if available
+    def included_in_monthly_price(self):
+        if self.state == 'available':
+            return True
+        else:
+            return False

--- a/app/ami.py
+++ b/app/ami.py
@@ -149,7 +149,7 @@ class Ami(Resource):
     def is_active(self):
         return self.state == 'available'
 
-    # Determine if resource can be stopped - AMIs cannot be
+    # Determine if resource has a 'stopped' state - AMIs don't
     @staticmethod
     def can_be_stopped() -> bool:
         return False

--- a/app/ami.py
+++ b/app/ami.py
@@ -31,7 +31,7 @@ class Ami(Resource):
                 'Monthly Price',
                 'Region Name',
                 'AMI Type',
-                'OS'
+                'OS',
                 'IOPS',
                 'VolumeType'
                 'Throughput']

--- a/app/ami.py
+++ b/app/ami.py
@@ -1,0 +1,8 @@
+@dataclass
+class Ami(Resource):
+    state: str
+    ec2_type: str
+    monthly_price: float
+    monthly_server_price: float
+    monthly_storage_price: float
+    size: float

--- a/app/ami.py
+++ b/app/ami.py
@@ -1,31 +1,21 @@
-# TODO make imports look like other files
-# from dataclasses import dataclass
-#
-# import resource
-# from resource import Resource
-# import boto3
-#
-# from datetime import datetime
 from dataclasses import dataclass
 
 from app import resource
 from .resource import Resource
 import boto3
-from .pricing import PricingData
 
 from datetime import datetime
 TODAY = datetime.today()
 TODAY_IS_WEEKEND = TODAY.weekday() >= 4  # Days are 0-6. 4=Friday, 5=Saturday, 6=Sunday, 0=Monday
 
 
-# Class representing an AMI
 @dataclass
 class Ami(Resource):
     state: str
     ec2_type: str
     monthly_price: float
 
-    # Return the type and state of the EC2 resource being examined ('ami' and 'available')
+    # Return the type and state of the AMI
     @staticmethod
     def to_string():
         return 'ami', 'available'
@@ -39,7 +29,7 @@ class Ami(Resource):
                 'Contact',
                 'Monthly Price',
                 'Region Name',
-                'Volume Type',
+                'AMI Type',
                 'OS'
                 'IOPS',
                 'Throughput']
@@ -74,7 +64,7 @@ class Ami(Resource):
                 amis.append(ami)
         return amis
 
-    # Get the info about a single EBS volume
+    # Get the info about a single AMI
     @staticmethod
     def build_model(region_name: str, resource_dict: dict):
         tags = resource.make_tags_dict(resource_dict.get('Tags', []))
@@ -114,16 +104,16 @@ class Ami(Resource):
 
     # Delete/terminate an AMI
     def terminate_resource(self, dryrun: bool) -> bool:
-        print(f'Deleting volume: {str(self.resource_id)}...')
+        print(f'Deleting AMI: {str(self.resource_id)}...')
         ec2 = boto3.resource('ec2', region_name=self.region_name)
         image = ec2.Image(self.resource_id)
         try:
             if not dryrun:
                 response = image.deregister()  # response should return None
-                print(f'Response from delete_volumes: {str(response)}')
+                print(f'Response from image.deregister() (should be None): {str(response)}')
             return True
         except Exception as e:
-            print(f'Failure when calling delete_volumes: {str(e)}')
+            print(f'Failure when calling image.deregister(): {str(e)}')
             return False
 
     def is_stoppable_without_warning(self):

--- a/app/ami.py
+++ b/app/ami.py
@@ -1,8 +1,179 @@
+# TODO make imports look like other files
+# from dataclasses import dataclass
+#
+# import resource
+# from resource import Resource
+# import boto3
+#
+# from datetime import datetime
+from dataclasses import dataclass
+
+from app import resource
+from .resource import Resource
+import boto3
+from .pricing import PricingData
+
+from datetime import datetime
+TODAY = datetime.today()
+TODAY_IS_WEEKEND = TODAY.weekday() >= 4  # Days are 0-6. 4=Friday, 5=Saturday, 6=Sunday, 0=Monday
+
+
+# Class representing an AMI
 @dataclass
 class Ami(Resource):
     state: str
     ec2_type: str
-    monthly_price: float
-    monthly_server_price: float
-    monthly_storage_price: float
-    size: float
+    # monthly_price: float
+    # monthly_server_price: float
+    # monthly_storage_price: float
+    # size: float
+
+    # Return the type and state of the EC2 resource being examined ('volume' and 'unattached')
+    @staticmethod
+    def to_string():
+        return 'volume', 'unattached'
+
+    # @staticmethod
+    # def to_header() -> [str]:
+    #     return ['Volume ID',
+    #             'Name',
+    #             'State',
+    #             'Terminate After',
+    #             'Contact',
+    #             'Monthly Price',
+    #             'Region Name',
+    #             'Volume Type',
+    #             'OS'
+    #             'Size',
+    #             'IOPS',
+    #             'Throughput']
+    #
+    # def to_list(self) -> [str]:
+    #     return [self.resource_id,
+    #             self.name,
+    #             self.state,
+    #             self.terminate_after,
+    #             self.contact,
+    #             self.monthly_price,
+    #             self.region_name,
+    #             self.resource_type,
+    #             self.operating_system,
+    #             self.size,
+    #             self.iops,
+    #             self.throughput]
+
+    # Get a list of model classes representing important properties of EBS volumes
+    @staticmethod
+    def list_resources():
+        describe_regions_response = Resource.generic_list_resources()
+        # print(describe_regions_response)
+
+        amis = []
+
+        for region in describe_regions_response['Regions']:
+            region_name = region['RegionName']
+            ec2 = boto3.client('ec2', region_name=region_name)
+            # TODO: does self work for aws subaccount? Or does that ID need to be explicitly included?
+            describe_images_response = ec2.describe_images(Owners=['self'])
+
+            for ami_dict in describe_images_response['Images']:
+                ami = Ami.build_model(region_name, ami_dict)
+                amis.append(ami)
+        return amis
+
+    # Get the info about a single EBS volume
+    @staticmethod
+    def build_model(region_name: str, resource_dict: dict):
+        tags = resource.make_tags_dict(resource_dict.get('Tags', []))
+
+        state = resource_dict['State']
+        ec2_type = 'ami'
+        # size = resource_dict['Size']  no size included for ami
+
+        resource_id_tag = 'ImageId'
+        resource_type_tag = 'ImageType'
+        ami = Resource.build_generic_model(tags, resource_dict, region_name, resource_id_tag, resource_type_tag)
+
+        # TODO: estimate monthly cost of ami
+        # monthly_price = resource.estimate_monthly_ami_price(region_name, ami.resource_id,
+        #                                                             ami.resource_type, size, ami.iops,
+        #                                                             ami.throughput)
+        # print(monthly_price)
+        # print()
+        # print(ami)
+        # monthly_server_price, monthly_storage_price = 0, 0
+
+        return Ami(region_name=region_name,
+                      resource_id=ami.resource_id,
+                      state=state,
+                      reason=ami.reason,
+                      resource_type=ami.resource_type,
+                      ec2_type=ec2_type,
+                      eks_nodegroup_name=ami.eks_nodegroup_name,
+                      name=ami.name,
+                      operating_system=ami.operating_system,
+                      # monthly_price=monthly_price,
+                      # monthly_server_price=monthly_server_price,
+                      # monthly_storage_price=monthly_storage_price,
+                      stop_after=ami.stop_after,
+                      terminate_after=ami.terminate_after,
+                      nagbot_state=ami.nagbot_state,
+                      contact=ami.contact,
+                      stop_after_tag_name=ami.stop_after_tag_name,
+                      terminate_after_tag_name=ami.terminate_after_tag_name,
+                      nagbot_state_tag_name=ami.nagbot_state_tag_name,
+                      # size=size,
+                      iops=ami.iops,
+                      throughput=ami.throughput)
+    #
+    # # Delete/terminate an EBS volume
+    # def terminate_resource(self, dryrun: bool) -> bool:
+    #     print(f'Deleting volume: {str(self.resource_id)}...')
+    #     ec2 = boto3.client('ec2', region_name=self.region_name)
+    #     try:
+    #         if not dryrun:
+    #             response = ec2.delete_volume(VolumeId=self.resource_id)
+    #             print(f'Response from delete_volumes: {str(response)}')
+    #         return True
+    #     except Exception as e:
+    #         print(f'Failure when calling delete_volumes: {str(e)}')
+    #         return False
+    #
+    # # Check if a volume is stoppable (should always be false)
+    # def is_stoppable(self, today_date, is_weekend=TODAY_IS_WEEKEND):
+    #     return self.generic_is_stoppable(self, today_date, is_weekend)
+    #
+    # # Check if a volume is deletable/terminatable
+    # def is_terminatable(self, today_date):
+    #     state = 'available'
+    #     return self.generic_is_terminatable(self, state, today_date)
+    #
+    # # Check if a volume is safe to stop (should always be false)
+    # def is_safe_to_stop(self, today_date, is_weekend=TODAY_IS_WEEKEND):
+    #     return self.generic_is_safe_to_stop(self, today_date, is_weekend)
+    #
+    # # Check if a volume is safe to delete/terminate
+    # def is_safe_to_terminate(self, today_date):
+    #     resource_type = Volume
+    #     return self.generic_is_safe_to_terminate(self, resource_type, today_date)
+    #
+    # # Create volume summary
+    # def make_resource_summary(self):
+    #     resource_type = Volume
+    #     link = self.make_generic_resource_summary(self, resource_type)
+    #     state = f'State={self.state}'
+    #     line = '{link}, {state}, Type={self.resource_type}'
+    #     return line
+    #
+    # # Create volume url
+    # @staticmethod
+    # def url_from_id(region_name, resource_id):
+    #     resource_type = 'Volumes'
+    #     return Resource.generic_url_from_id(region_name, resource_id, resource_type)
+    #
+    # # Include volume in monthly price calculation if available
+    # def included_in_monthly_price(self):
+    #     if self.state == 'available':
+    #         return True
+    #     else:
+    #         return False

--- a/app/ami.py
+++ b/app/ami.py
@@ -8,6 +8,7 @@ import boto3
 from datetime import datetime
 TODAY = datetime.today()
 TODAY_IS_WEEKEND = TODAY.weekday() >= 4  # Days are 0-6. 4=Friday, 5=Saturday, 6=Sunday, 0=Monday
+ORG_AMIS = False
 
 
 @dataclass
@@ -200,3 +201,13 @@ def estimate_monthly_ami_price(ami_type: str, block_device_mappings: list, ami_n
         print(f"WARNING: {ami_name} is a {ami_type} type AMI with the following block_device_mappings: "
               f"{block_device_mappings}")
     return total_cost
+
+
+def is_ami_registered(ami_id: str, ) -> bool:
+    # Use global variable to make API call once instead of every time the method is called since call is costly
+    global ORG_AMIS
+    if not ORG_AMIS:
+        ec2_client = boto3.client('ec2')
+        ORG_AMIS = ec2_client.describe_images(Owners=['self'])
+    # Iterate through each image owned by organization to check if ami id exists, if it does it is registered
+    return True if [i['ImageId'] for i in ORG_AMIS['Images'] if i['ImageId'] == ami_id] else False

--- a/app/ami.py
+++ b/app/ami.py
@@ -149,6 +149,11 @@ class Ami(Resource):
     def is_active(self):
         return self.state == 'available'
 
+    # Determine if resource can be stopped - AMIs cannot be
+    @staticmethod
+    def can_be_stopped() -> bool:
+        return False
+
     # Create ami summary
     def make_resource_summary(self):
         resource_type = Ami

--- a/app/ami.py
+++ b/app/ami.py
@@ -198,5 +198,5 @@ def estimate_monthly_ami_price(ami_type: str, block_device_mappings: list, ami_n
                 total_cost += estimate_monthly_snapshot_price(snapshot_type, snapshot_size)
     else:
         print(f"WARNING: {ami_name} is a {ami_type} type AMI with the following block_device_mappings: "
-              "{block_device_mappings}")
+              f"{block_device_mappings}")
     return total_cost

--- a/app/ami.py
+++ b/app/ami.py
@@ -208,7 +208,7 @@ def estimate_monthly_ami_price(ami_type: str, block_device_mappings: list, ami_n
     return total_cost
 
 
-def is_ami_registered(ami_id: str, ) -> bool:
+def is_ami_registered(ami_id: str) -> bool:
     ec2 = boto3.resource('ec2')
     is_registered = True
     # Retrieve name of AMI, if ClientError or AttributeError is thrown, the AMI does not exist

--- a/app/ami.py
+++ b/app/ami.py
@@ -143,6 +143,10 @@ class Ami(Resource):
         resource_type = Ami
         return self.generic_is_safe_to_terminate(self, resource_type, today_date)
 
+    # Check if a instance is active
+    def is_active(self):
+        return True if self.state == 'available' else False
+
     # Create ami summary
     def make_resource_summary(self):
         resource_type = Ami

--- a/app/ami.py
+++ b/app/ami.py
@@ -146,7 +146,7 @@ class Ami(Resource):
 
     # Check if a instance is active
     def is_active(self):
-        return True if self.state == 'available' else False
+        return self.state == 'available'
 
     # Create ami summary
     def make_resource_summary(self):

--- a/app/ami.py
+++ b/app/ami.py
@@ -80,7 +80,6 @@ class Ami(Resource):
         block_device_mappings = resource_dict['BlockDeviceMappings']  # the collection of ebs snapshots forming the ami
 
         monthly_price = resource.estimate_monthly_ami_price(ami_type, block_device_mappings, name)
-        print(monthly_price)
 
         return Ami(region_name=region_name,
                       resource_id=ami.resource_id,

--- a/app/instance.py
+++ b/app/instance.py
@@ -11,7 +11,6 @@ TODAY = datetime.today()
 TODAY_IS_WEEKEND = TODAY.weekday() >= 4  # Days are 0-6. 4=Friday, 5=Saturday, 6=Sunday, 0=Monday
 
 
-# Class representing an EC2 instance
 @dataclass
 class Instance(Resource):
     state: str

--- a/app/instance.py
+++ b/app/instance.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from app import resource
 from .resource import Resource
+from .volume import estimate_monthly_ebs_storage_price
 import boto3
 from .pricing import PricingData
 
@@ -92,8 +93,8 @@ class Instance(Resource):
         pricing = PricingData()
         monthly_server_price = pricing.lookup_monthly_price(region_name, instance.resource_type,
                                                             instance.operating_system)
-        monthly_storage_price = resource.estimate_monthly_ebs_storage_price(region_name,
-                                                                            instance.resource_id, 'none', 0, 0, 0)
+        monthly_storage_price = estimate_monthly_ebs_storage_price(region_name,
+                                                                   instance.resource_id, 'none', 0, 0, 0)
         monthly_price = (monthly_server_price + monthly_storage_price) if state == 'running' else monthly_storage_price
 
         size = 0

--- a/app/instance.py
+++ b/app/instance.py
@@ -160,7 +160,7 @@ class Instance(Resource):
     def is_active(self):
         return True if self.state == 'running' else False
 
-    # Determine if resource can be stopped - EC2 Instances can be
+    # Determine if resource has a 'stopped' state - EC2 Instances do
     @staticmethod
     def can_be_stopped() -> bool:
         return True

--- a/app/instance.py
+++ b/app/instance.py
@@ -24,7 +24,7 @@ class Instance(Resource):
     # Return the type and state of the EC2 resource being examined ('instance' and 'running')
     @staticmethod
     def to_string():
-        return 'instance', 'running'  # TODO: why do we assume this is running?
+        return 'instance', 'running'
 
     @staticmethod
     def to_header() -> [str]:
@@ -159,6 +159,11 @@ class Instance(Resource):
     # Check if a instance is active
     def is_active(self):
         return True if self.state == 'running' else False
+
+    # Determine if resource can be stopped - EC2 Instances can be
+    @staticmethod
+    def can_be_stopped() -> bool:
+        return True
 
     # Create instance summary
     def make_resource_summary(self):

--- a/app/instance.py
+++ b/app/instance.py
@@ -155,6 +155,10 @@ class Instance(Resource):
         resource_type = Instance
         return self.generic_is_safe_to_terminate(self, resource_type, today_date)
 
+    # Check if a instance is active
+    def is_active(self):
+        return True if self.state == 'running' else False
+
     # Create instance summary
     def make_resource_summary(self):
         resource_type = Instance

--- a/app/instance.py
+++ b/app/instance.py
@@ -24,7 +24,7 @@ class Instance(Resource):
     # Return the type and state of the EC2 resource being examined ('instance' and 'running')
     @staticmethod
     def to_string():
-        return 'instance', 'running'
+        return 'instance', 'running'  # TODO: why do we assume this is running?
 
     @staticmethod
     def to_header() -> [str]:
@@ -158,10 +158,10 @@ class Instance(Resource):
         resource_type = Instance
         link = self.make_generic_resource_summary(self, resource_type)
         if self.reason:
-            state = 'State=({}, "{}")'.format(self.state, self.reason)
+            state = f'State=({self.state}, "{self.reason}")'
         else:
-            state = 'State={}'.format(self.state)
-        line = '{}, {}, Type={}'.format(link, state, self.resource_type)
+            state = f'State={self.state}'
+        line = f'{link}, {state}, Type={self.resource_type}'
         return line
 
     # Create instance url

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -2,10 +2,6 @@ __author__ = "Stephen Rosenthal"
 __version__ = "1.10.1"
 __license__ = "MIT"
 
-# TODO: What defines a "stopped" snapshot, ami, and volume?
-# TODO: include how to test changes in development in the README, put SLACK_BOT_TOKEN on Keeper
-# TODO: create a NagBot Confluence page
-
 import argparse
 import re
 import sys
@@ -46,7 +42,6 @@ class Nagbot(object):
         for resource_type in RESOURCE_TYPES:
             ec2_type, ec2_state = resource_type.to_string()
             resources = resource_type.list_resources()
-            # TODO: what makes a snapshot or ami considered a running resource? include that here.
             num_running_resources = sum(1 for r in resources if r.state in ['running', 'available', 'completed'])
             num_total_resources = len(resources)
 
@@ -74,7 +69,6 @@ class Nagbot(object):
             else:
                 summary_msg += f'No {ec2_type}s are due to be terminated at this time.\n'
 
-            # TODO: the following applies only to instances and should only be ran in that case
             if ec2_type == "instance":
                 if len(resources_to_stop) > 0:
                     summary_msg += f'The following {len(resources_to_stop)} _{ec2_state}_ {ec2_type}s ' \

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -46,9 +46,9 @@ class Nagbot(object):
 
             running_monthly_cost = money_to_string(sum(r.monthly_price for r in resources
                                                        if r.included_in_monthly_price()))
-            summary_msg += f"\nWe have {num_active_resources} {ec2_state} {ec2_type}s right now and" \
-                           f" {num_total_resources} total.\n"
-            summary_msg += f"If we continue to run these {ec2_type}s all month, it would cost {running_monthly_cost}.\n"
+            summary_msg += f"\n*{resource_type.__name__}s*\nWe have {num_active_resources} " \
+                           f"{ec2_state} {ec2_type}s right now and {num_total_resources} total.\n" \
+                           f"If we continue to run these {ec2_type}s all month, it would cost {running_monthly_cost}.\n"
 
             resources = sorted((r for r in resources if not (len(r.eks_nodegroup_name) > 0)), key=lambda i: i.name)
 
@@ -68,7 +68,7 @@ class Nagbot(object):
             else:
                 summary_msg += f'No {ec2_type}s are due to be terminated at this time.\n'
 
-            if ec2_type == "instance":
+            if resource_type.can_be_stopped():
                 if len(resources_to_stop) > 0:
                     summary_msg += f'The following {len(resources_to_stop)} _{ec2_state}_ {ec2_type}s ' \
                                'are due to be *STOPPED*, based on the "Stop after" tag:\n'

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -2,6 +2,10 @@ __author__ = "Stephen Rosenthal"
 __version__ = "1.10.1"
 __license__ = "MIT"
 
+# TODO: What defines a "stopped" snapshot, ami, and volume?
+# TODO: include how to test changes in development in the README, put SLACK_BOT_TOKEN on Keeper
+# TODO: create a NagBot Confluence page
+
 import argparse
 import re
 import sys
@@ -13,11 +17,13 @@ from . import sqslack
 from .resource import money_to_string
 from .instance import Instance
 from .volume import Volume
+from .ami import Ami
+from .snapshot import Snapshot
 
 TODAY = datetime.today()
 TODAY_YYYY_MM_DD = TODAY.strftime('%Y-%m-%d')
 
-RESOURCE_TYPES = [Instance, Volume]
+RESOURCE_TYPES = [Instance, Volume, Snapshot]
 
 """
 PREREQUISITES:
@@ -33,63 +39,64 @@ PREREQUISITES:
 class Nagbot(object):
     @staticmethod
     def notify_internal(channel, dryrun):
-        summary_msg = "Hi, I'm Nagbot v{} :wink: ".format(__version__)
+        summary_msg = f"Hi, I'm Nagbot v{__version__} :wink: "
         summary_msg += "My job is to make sure we don't forget about unwanted AWS resources and waste money!\n"
 
         for resource_type in RESOURCE_TYPES:
             ec2_type, ec2_state = resource_type.to_string()
             resources = resource_type.list_resources()
-            num_running_resources = sum(1 for r in resources if r.state == 'running' or r.state == 'available')
+            # TODO: what makes a snapshot or ami considered a running resource? include that here.
+            num_running_resources = sum(1 for r in resources if r.state in ['running', 'available', 'completed'])
             num_total_resources = len(resources)
 
             running_monthly_cost = money_to_string(sum(r.monthly_price for r in resources
                                                        if r.included_in_monthly_price()))
-            summary_msg += "\nWe have {} {} {}s right now and {} total.\n".format(num_running_resources, ec2_state,
-                                                                                  ec2_type, num_total_resources)
-            summary_msg += "If we continue to run these {}s all month, it would cost {}.\n" \
-                .format(ec2_type, running_monthly_cost)
+            summary_msg += f"\nWe have {num_running_resources} {ec2_state} {ec2_type}s right now and" \
+                           f" {num_total_resources} total.\n"
+            summary_msg += f"If we continue to run these {ec2_type}s all month, it would cost {running_monthly_cost}.\n"
 
             resources = sorted((r for r in resources if not (len(r.eks_nodegroup_name) > 0)), key=lambda i: i.name)
 
             resources_to_terminate = (list(r for r in resources if r.is_terminatable(TODAY_YYYY_MM_DD)))
             resources_to_stop = list(r for r in resources if r.is_stoppable(today_date=TODAY_YYYY_MM_DD))
 
+            # TODO: Snapshots, EBS volumes, and AMIs cannot be stopped, so _stopped_ should only apply to EC2
+            #  instances. Correct the output in aws channel for volumes to use correct terminology. Also clean up
+            #  the output so it looks neater.
             if len(resources_to_terminate) > 0:
-                summary_msg += 'The following %d _stopped_ {}s are due to be *TERMINATED*, ' \
-                                'based on the "Terminate after" tag:\n'.format(ec2_type) \
-                                % len(resources_to_terminate)
+                summary_msg += f'The following {len(resources_to_terminate)} {ec2_type}s are due to be *TERMINATED*, ' \
+                               'based on the "Terminate after" tag:\n'
                 for r in resources_to_terminate:
                     contact = sqslack.lookup_user_by_email(r.contact)
                     summary_msg += r.make_resource_summary() + \
-                        ', "Terminate after"={}, "Monthly Price"={}, Contact={}\n' \
-                        .format(r.terminate_after, money_to_string(r.monthly_price), contact)
+                        f', "Terminate after"={r.terminate_after}, "Monthly Price"={money_to_string(r.monthly_price)}' \
+                        f', Contact={contact}\n'
                     resource.set_tag(r.region_name, r.ec2_type, r.resource_id, r.terminate_after_tag_name,
                                      parsing.add_warning_to_tag(r.terminate_after, TODAY_YYYY_MM_DD), dryrun=dryrun)
             else:
-                summary_msg += 'No {}s are due to be terminated at this time.\n' \
-                    .format(ec2_type)
+                summary_msg += f'No {ec2_type}s are due to be terminated at this time.\n'
 
-            if len(resources_to_stop) > 0:
-                summary_msg += 'The following %d _{}_ {}s are due to be *STOPPED*, ' \
-                           'based on the "Stop after" tag:\n'.format(ec2_state, ec2_type) \
-                           % len(resources_to_stop)
-                for r in resources_to_stop:
-                    contact = sqslack.lookup_user_by_email(r.contact)
-                    summary_msg += r.make_resource_summary() + ', "Stop after"={}, "Monthly Price"={}, Contact={}\n' \
-                        .format(r.stop_after, money_to_string(r.monthly_price), contact)
-                    resource.set_tag(r.region_name, r.ec2_type, r.resource_id, r.stop_after_tag_name,
-                                     parsing.add_warning_to_tag(r.stop_after, TODAY_YYYY_MM_DD, replace=True),
-                                     dryrun=dryrun)
-            else:
-                summary_msg += 'No {}s are due to be stopped at this time.\n'.format(ec2_type)
-
+            # TODO: the following applies only to instances and should only be ran in that case
+            if ec2_type == "instance":
+                if len(resources_to_stop) > 0:
+                    summary_msg += f'The following {len(resources_to_stop)} _{ec2_state}_ {ec2_type}s ' \
+                               'are due to be *STOPPED*, based on the "Stop after" tag:\n'
+                    for r in resources_to_stop:
+                        contact = sqslack.lookup_user_by_email(r.contact)
+                        summary_msg += f'{r.make_resource_summary()}, "Stop after"={r.stop_after}, ' \
+                                       f'Monthly Price"={money_to_string(r.monthly_price)}, Contact={contact}\n'
+                        resource.set_tag(r.region_name, r.ec2_type, r.resource_id, r.stop_after_tag_name,
+                                         parsing.add_warning_to_tag(r.stop_after, TODAY_YYYY_MM_DD, replace=True),
+                                         dryrun=dryrun)
+                else:
+                    summary_msg += f'No {ec2_type}s are due to be stopped at this time.\n'
         sqslack.send_message(channel, summary_msg)
 
     def notify(self, channel, dryrun):
         try:
             self.notify_internal(channel, dryrun)
         except Exception as e:
-            sqslack.send_message(channel, "Nagbot failed to run the 'notify' command: " + str(e))
+            sqslack.send_message(channel, f"Nagbot failed to run the 'notify' command: {str(e)}")
             raise e
 
     @staticmethod
@@ -107,37 +114,36 @@ class Nagbot(object):
                                      and r.is_safe_to_stop(today_date=TODAY_YYYY_MM_DD))
 
             if len(resources_to_terminate) > 0:
-                message = 'I terminated the following {}s: '.format(ec2_type)
+                message = f'I terminated the following {ec2_type}s: '
                 for r in resources_to_terminate:
                     contact = sqslack.lookup_user_by_email(r.contact)
                     message = message + r.make_resource_summary() + \
-                        ', "Terminate after"={}, "Monthly Price"={}, Contact={}\n' \
-                        .format(r.terminate_after, money_to_string(r.monthly_price), contact)
+                        f', "Terminate after"={r.terminate_after}, "Monthly Price"=' \
+                        f'{money_to_string(r.monthly_price)}, Contact={contact}\n'
                     r.terminate_resource(dryrun=dryrun)
                 sqslack.send_message(channel, message)
             else:
-                sqslack.send_message(channel, 'No {}s were terminated today.'
-                                     .format(ec2_type))
+                sqslack.send_message(channel, f'No {ec2_type}s were terminated today.')
 
-            if len(resources_to_stop) > 0:
-                message = 'I stopped the following {}s: '.format(ec2_type)
-                for r in resources_to_stop:
-                    contact = sqslack.lookup_user_by_email(r.contact)
-                    message = message + r.make_resource_summary() + \
-                        ', "Stop after"={}, "Monthly Price"={}, Contact={}\n' \
-                        .format(r.stop_after, money_to_string(r.monthly_price), contact)
-                    resource.stop_resource(r.region_name, r.resource_id, dryrun=dryrun)
-                    resource.set_tag(r.region_name, r.ec2_type, r.resource_id, r.nagbot_state_tag_name, 'Stopped on '
-                                     + TODAY_YYYY_MM_DD, dryrun=dryrun)
-                sqslack.send_message(channel, message)
-            else:
-                sqslack.send_message(channel, 'No {}s were stopped today.'.format(ec2_type))
+            if resource_type == "Instance":
+                if len(resources_to_stop) > 0:
+                    message = f'I stopped the following {ec2_type}s: '
+                    for r in resources_to_stop:
+                        contact = sqslack.lookup_user_by_email(r.contact)
+                        message = message + r.make_resource_summary() + \
+                            f', "Stop after"={r.stop_after}, "Monthly Price"={r.monthly_price}, Contact={contact}\n'
+                        resource.stop_resource(r.region_name, r.resource_id, dryrun=dryrun)
+                        resource.set_tag(r.region_name, r.ec2_type, r.resource_id, r.nagbot_state_tag_name,
+                                         f'Stopped on {TODAY_YYYY_MM_DD}', dryrun=dryrun)
+                    sqslack.send_message(channel, message)
+                else:
+                    sqslack.send_message(channel, f'No {ec2_type}s were stopped today.')
 
     def execute(self, channel, dryrun):
         try:
             self.execute_internal(channel, dryrun)
         except Exception as e:
-            sqslack.send_message(channel, "Nagbot failed to run the 'execute' command: " + str(e))
+            sqslack.send_message(channel, f"Nagbot failed to run the 'execute' command: {str(e)}")
             raise e
 
 
@@ -150,9 +156,9 @@ def main(args):
     dryrun = args.dryrun
 
     if re.fullmatch(r'#[A-Za-z\d-]+', channel) is None:
-        print('Unexpected channel format "%s", should look like #random or #testing' % channel)
+        print(f'Unexpected channel format "{channel}", should look like #random or #testing')
         sys.exit(1)
-    print('Destination Slack channel is: ' + channel)
+    print(f'Destination Slack channel is: {channel}')
 
     nagbot = Nagbot()
 
@@ -161,7 +167,7 @@ def main(args):
     elif mode.lower() == 'execute':
         nagbot.execute(channel, dryrun)
     else:
-        print('Unexpected mode "%s", should be "notify" or "execute"' % mode)
+        print(f'Unexpected mode "{mode}", should be "notify" or "execute"')
         sys.exit(1)
 
 
@@ -176,7 +182,7 @@ if __name__ == "__main__":
         "-c",
         "--channel",
         action="store",
-        default='#nagbot-testing',
+        default='#bot-testing',
         help="Which Slack channel to publish to")
 
     parser.add_argument(

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -41,12 +41,12 @@ class Nagbot(object):
         for resource_type in RESOURCE_TYPES:
             ec2_type, ec2_state = resource_type.to_string()
             resources = resource_type.list_resources()
-            num_running_resources = sum(1 for r in resources if r.state in ['running', 'available', 'completed'])
+            num_active_resources = sum(1 for r in resources if r.is_active())
             num_total_resources = len(resources)
 
             running_monthly_cost = money_to_string(sum(r.monthly_price for r in resources
                                                        if r.included_in_monthly_price()))
-            summary_msg += f"\nWe have {num_running_resources} {ec2_state} {ec2_type}s right now and" \
+            summary_msg += f"\nWe have {num_active_resources} {ec2_state} {ec2_type}s right now and" \
                            f" {num_total_resources} total.\n"
             summary_msg += f"If we continue to run these {ec2_type}s all month, it would cost {running_monthly_cost}.\n"
 

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -1,5 +1,5 @@
 __author__ = "Stephen Rosenthal"
-__version__ = "1.10.1"
+__version__ = "1.11.0"
 __license__ = "MIT"
 
 import argparse

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -23,7 +23,8 @@ from .snapshot import Snapshot
 TODAY = datetime.today()
 TODAY_YYYY_MM_DD = TODAY.strftime('%Y-%m-%d')
 
-RESOURCE_TYPES = [Instance, Volume, Snapshot]
+# RESOURCE_TYPES = [Instance, Volume, Snapshot]
+RESOURCE_TYPES = [Ami]
 
 """
 PREREQUISITES:
@@ -60,9 +61,6 @@ class Nagbot(object):
             resources_to_terminate = (list(r for r in resources if r.is_terminatable(TODAY_YYYY_MM_DD)))
             resources_to_stop = list(r for r in resources if r.is_stoppable(today_date=TODAY_YYYY_MM_DD))
 
-            # TODO: Snapshots, EBS volumes, and AMIs cannot be stopped, so _stopped_ should only apply to EC2
-            #  instances. Correct the output in aws channel for volumes to use correct terminology. Also clean up
-            #  the output so it looks neater.
             if len(resources_to_terminate) > 0:
                 summary_msg += f'The following {len(resources_to_terminate)} {ec2_type}s are due to be *TERMINATED*, ' \
                                'based on the "Terminate after" tag:\n'

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -19,7 +19,7 @@ from .snapshot import Snapshot
 TODAY = datetime.today()
 TODAY_YYYY_MM_DD = TODAY.strftime('%Y-%m-%d')
 
-RESOURCE_TYPES = [Instance, Volume, Snapshot, Ami]
+RESOURCE_TYPES = [Instance, Ami, Snapshot, Volume]
 
 """
 PREREQUISITES:

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -19,8 +19,7 @@ from .snapshot import Snapshot
 TODAY = datetime.today()
 TODAY_YYYY_MM_DD = TODAY.strftime('%Y-%m-%d')
 
-# RESOURCE_TYPES = [Instance, Volume, Snapshot]
-RESOURCE_TYPES = [Ami]
+RESOURCE_TYPES = [Instance, Volume, Snapshot, Ami]
 
 """
 PREREQUISITES:

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -46,7 +46,7 @@ class Nagbot(object):
 
             running_monthly_cost = money_to_string(sum(r.monthly_price for r in resources
                                                        if r.included_in_monthly_price()))
-            summary_msg += f"\n*{resource_type.__name__}s*\nWe have {num_active_resources} " \
+            summary_msg += f"\n*{resource_type.__name__}s:*\nWe have {num_active_resources} " \
                            f"{ec2_state} {ec2_type}s right now and {num_total_resources} total.\n" \
                            f"If we continue to run these {ec2_type}s all month, it would cost {running_monthly_cost}.\n"
 

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -87,7 +87,7 @@ class Nagbot(object):
         try:
             self.notify_internal(channel, dryrun)
         except Exception as e:
-            sqslack.send_message(channel, f"Nagbot failed to run the 'notify' command: {str(e)}")
+            sqslack.send_message(channel, f"Nagbot failed to run the 'notify' command: {e}")
             raise e
 
     @staticmethod

--- a/app/resource.py
+++ b/app/resource.py
@@ -82,17 +82,17 @@ def estimate_monthly_snapshot_price(type: str, size: float) -> float:
 
 def estimate_monthly_ami_price(type: str, block_device_mappings: list, ami: str) -> float:
     total_cost = 0
-    # Logic is only implemented for ebs-backed AMIs since to date we do not use instance-backed AMIs at Seeq
+    # Logic is only implemented for ebs-backed AMIs since Seeq does not use instance-backed AMIs
     if type == 'ebs':
         for device in block_device_mappings:
-            # TODO: do not use try / catch and implement logic for instance-store backed AMIs
-            try:
+            # Some AMIs contain block devices which are ephemeral volumes -this is indicative of an instance-backed AMI,
+            # but we do not contain any s3 with bundles for AMIs, so these ephemeral volumes should only cost money
+            # when an instance is fired up from the AMI, therefore this cost is not included in the sum total.
+            if "Ebs" in device.keys():
                 snapshot = device["Ebs"]
-            except:
-                print(ami)
-            snapshot_type = snapshot["VolumeType"]
-            snapshot_size = snapshot["VolumeSize"]
-            total_cost += estimate_monthly_snapshot_price(snapshot_type, snapshot_size)
+                snapshot_type = snapshot["VolumeType"]
+                snapshot_size = snapshot["VolumeSize"]
+                total_cost += estimate_monthly_snapshot_price(snapshot_type, snapshot_size)
     return total_cost
 
 

--- a/app/resource.py
+++ b/app/resource.py
@@ -80,6 +80,21 @@ def estimate_monthly_snapshot_price(type: str, size: float) -> float:
     archive_monthly_cost = .0131
     return standard_monthly_cost*size if type == "standard" else archive_monthly_cost*size
 
+def estimate_monthly_ami_price(type: str, block_device_mappings: list, ami: str) -> float:
+    total_cost = 0
+    # Logic is only implemented for ebs-backed AMIs since to date we do not use instance-backed AMIs at Seeq
+    if type == 'ebs':
+        for device in block_device_mappings:
+            # TODO: do not use try / catch and implement logic for instance-store backed AMIs
+            try:
+                snapshot = device["Ebs"]
+            except:
+                print(ami)
+            snapshot_type = snapshot["VolumeType"]
+            snapshot_size = snapshot["VolumeSize"]
+            total_cost += estimate_monthly_snapshot_price(snapshot_type, snapshot_size)
+    return total_cost
+
 
 # Stop an EC2 resource - currently, only instances should be able to be stopped
 def stop_resource(region_name: str, instance_id: str, dryrun: bool) -> bool:

--- a/app/resource.py
+++ b/app/resource.py
@@ -82,10 +82,10 @@ def estimate_monthly_snapshot_price(type: str, size: float) -> float:
     archive_monthly_cost = .0131
     return standard_monthly_cost*size if type == "standard" else archive_monthly_cost*size
 
-def estimate_monthly_ami_price(type: str, block_device_mappings: list, ami: str) -> float:
+def estimate_monthly_ami_price(ami_type: str, block_device_mappings: list, ami_name: str) -> float:
     total_cost = 0
     # Logic is only implemented for ebs-backed AMIs since Seeq does not use instance-backed AMIs
-    if type == 'ebs':
+    if ami_type == 'ebs':
         for device in block_device_mappings:
             # Some AMIs contain block devices which are ephemeral volumes -this is indicative of an instance-backed AMI,
             # but we do not contain any s3 with bundles for AMIs, so these ephemeral volumes should only cost money
@@ -95,6 +95,9 @@ def estimate_monthly_ami_price(type: str, block_device_mappings: list, ami: str)
                 snapshot_type = snapshot["VolumeType"]
                 snapshot_size = snapshot["VolumeSize"]
                 total_cost += estimate_monthly_snapshot_price(snapshot_type, snapshot_size)
+    else:
+        print(f"WARNING: {ami_name} is a {ami_type} type AMI with the following block_device_mappings: "
+              "{block_device_mappings}")
     return total_cost
 
 

--- a/app/resource.py
+++ b/app/resource.py
@@ -74,6 +74,13 @@ def estimate_monthly_ebs_storage_price(region_name: str, instance_id: str, volum
         return size * 0.1
 
 
+# Estimated monthly costs were formulated by taking the average monthly costs of N. California and Oregon
+def estimate_monthly_snapshot_price(type: str, size: float) -> float:
+    standard_monthly_cost = .0525
+    archive_monthly_cost = .0131
+    return standard_monthly_cost*size if type == "standard" else archive_monthly_cost*size
+
+
 # Stop an EC2 resource - currently, only instances should be able to be stopped
 def stop_resource(region_name: str, instance_id: str, dryrun: bool) -> bool:
     print(f'Stopping instance: {str(instance_id)}...')
@@ -198,11 +205,11 @@ class Resource:
     def make_generic_resource_summary(resource, resource_type):
         resource_id = resource.resource_id
         resource_url = resource_type.url_from_id(resource.region_name, resource_id)
-        link = '<{}|{}>'.format(resource_url, resource.name)
+        link = f'<{resource_url}|{resource.name}>'
         return link
 
     # Create resource url
     @staticmethod
     def generic_url_from_id(region_name, resource_id, resource_type):
-        return 'https://{}.console.aws.amazon.com/ec2/v2/home?region={}#{}:search={}'.format(region_name, region_name,
-                                                                                             resource_type, resource_id)
+        return f'https://{region_name}.console.aws.amazon.com/ec2/v2/home?region={region_name}#{resource_type}:' \
+               f'search={resource_id}'

--- a/app/snapshot.py
+++ b/app/snapshot.py
@@ -153,6 +153,10 @@ class Snapshot(Resource):
         resource_type = Snapshot
         return self.generic_is_safe_to_terminate(self, resource_type, today_date)
 
+    # Check if a snapshot is active
+    def is_active(self):
+        return True if self.state == 'completed' else False
+
     # Create snapshot summary
     def make_resource_summary(self):
         resource_type = Snapshot

--- a/app/snapshot.py
+++ b/app/snapshot.py
@@ -155,7 +155,7 @@ class Snapshot(Resource):
     def is_active(self):
         return True if self.state == 'completed' else False
 
-    # Determine if resource can be stopped - Snapshots cannot be
+    # Determine if resource has a 'stopped' state - Snapshots don't
     @staticmethod
     def can_be_stopped() -> bool:
         return False

--- a/app/snapshot.py
+++ b/app/snapshot.py
@@ -73,7 +73,7 @@ class Snapshot(Resource):
         tags = resource.make_tags_dict(resource_dict.get('Tags', []))
         state = resource_dict['State']
         ec2_type = 'snapshot'
-        size = resource_dict['SnapshotSize']
+        size = resource_dict['VolumeSize']
         snapshot_type = resource_dict['StorageTier']
         resource_id_tag = 'SnapshotId'
         resource_type_tag = 'StorageTier'

--- a/app/snapshot.py
+++ b/app/snapshot.py
@@ -108,7 +108,6 @@ class Snapshot(Resource):
                    iops=snapshot.iops,
                    throughput=snapshot.throughput)
 
-    # TODO: make a test volume and verify this works by calling this function on that specific resource
     # Delete/terminate an EBS volume
     def terminate_resource(self, dryrun: bool) -> bool:
         print(f'Deleting snapshot: {str(self.resource_id)}...')
@@ -133,8 +132,6 @@ class Snapshot(Resource):
     # Check if a snapshot is deletable/terminatable
     def is_terminatable(self, today_date):
         state = 'completed'
-        # TODO: question - since snapshot state is always completed pretty much, are they all
-        #   considered terminatable?
         return self.generic_is_terminatable(self, state, today_date)
 
     # Check if a volume is safe to stop (should always be false)

--- a/app/snapshot.py
+++ b/app/snapshot.py
@@ -1,8 +1,165 @@
+from dataclasses import dataclass
+
+from app import resource
+from .resource import Resource
+import boto3
+from .pricing import PricingData
+
+from datetime import datetime
+
+TODAY = datetime.today()
+TODAY_IS_WEEKEND = TODAY.weekday() >= 4  # Days are 0-6. 4=Friday, 5=Saturday, 6=Sunday, 0=Monday
+
+
+# Class representing an AMI
 @dataclass
 class Snapshot(Resource):
     state: str
     ec2_type: str
     monthly_price: float
-    monthly_server_price: float
-    monthly_storage_price: float
     size: float
+
+    @staticmethod
+    def to_string():
+        return 'snapshot', 'completed'
+
+    @staticmethod
+    def to_header() -> [str]:
+        return ['Snapshot ID',
+                'Name',
+                'State',
+                'Terminate After',
+                'Contact',
+                'Monthly Price',
+                'Region Name',
+                'Snapshot Type',
+                'OS'
+                'Size',
+                'IOPS',
+                'Throughput']
+
+    def to_list(self) -> [str]:
+        return [self.resource_id,
+                self.name,
+                self.state,
+                self.terminate_after,
+                self.contact,
+                self.monthly_price,
+                self.region_name,
+                self.resource_type,
+                self.operating_system,
+                self.size,
+                self.iops,
+                self.throughput]
+
+    # Get a list of model classes representing important properties of snapshots
+    @staticmethod
+    def list_resources():
+        describe_regions_response = Resource.generic_list_resources()
+
+        snapshots = []
+
+        for region in describe_regions_response['Regions']:
+            region_name = region['RegionName']
+            ec2 = boto3.client('ec2', region_name=region_name)
+            # TODO: does self work for aws subaccount? Or does that ID need to be explicitly included?
+            describe_snapshots_response = ec2.describe_snapshots(OwnerIds=["self"])
+
+            for snapshot_dict in describe_snapshots_response['Snapshots']:
+                snapshot = Snapshot.build_model(region_name, snapshot_dict)
+                snapshots.append(snapshot)
+        return snapshots
+
+    # build snapshot object
+    # TODO: delete me {'Description': 'Copied for DestinationAmi ami-0e6b2df6143644570 from SourceAmi ami-0895d2b50444605b2 for SourceSnapshot snap-090514a1fc3449642. Task created on 1,629,998,298,383.', 'Encrypted': False, 'OwnerId': '453803366167', 'Progress': '100%', 'SnapshotId': 'snap-0bac48b74e9339b3f', 'StartTime': datetime.datetime(2021, 8, 26, 17, 18, 20, 228000, tzinfo=tzutc()), 'State': 'completed', 'VolumeId': 'vol-ffffffff', 'VolumeSize': 256, 'StorageTier': 'standard'}
+    @staticmethod
+    def build_model(region_name: str, resource_dict: dict):
+        tags = resource.make_tags_dict(resource_dict.get('Tags', []))
+
+        state = resource_dict['State']
+        ec2_type = 'snapshot'
+        size = resource_dict['VolumeSize']
+        snapshot_type = resource_dict['StorageTier']
+        resource_id_tag = 'SnapshotId'
+        resource_type_tag = 'StorageTier'
+
+        snapshot = Resource.build_generic_model(tags, resource_dict, region_name, resource_id_tag, resource_type_tag)
+
+        monthly_price = resource.estimate_monthly_snapshot_price(snapshot_type, size)
+
+        return Snapshot(region_name=region_name,
+                   resource_id=snapshot.resource_id,
+                   state=state,
+                   reason=snapshot.reason,
+                   resource_type=snapshot.resource_type,
+                   ec2_type=ec2_type,
+                   eks_nodegroup_name=snapshot.eks_nodegroup_name,
+                   name=snapshot.name,
+                   operating_system=snapshot.operating_system,
+                   monthly_price=monthly_price,
+                   stop_after=snapshot.stop_after,
+                   terminate_after=snapshot.terminate_after,
+                   nagbot_state=snapshot.nagbot_state,
+                   contact=snapshot.contact,
+                   stop_after_tag_name=snapshot.stop_after_tag_name,
+                   terminate_after_tag_name=snapshot.terminate_after_tag_name,
+                   nagbot_state_tag_name=snapshot.nagbot_state_tag_name,
+                   size=size,
+                   iops=snapshot.iops,
+                   throughput=snapshot.throughput)
+
+    # TODO: make a test volume and verify this works by calling this function on that specific resource
+    # Delete/terminate an EBS volume
+    def terminate_resource(self, dryrun: bool) -> bool:
+        print(f'Deleting snapshot: {str(self.resource_id)}...')
+        ec2 = boto3.client('ec2', region_name=self.region_name)
+        snapshot = ec2.Snapshot(self.resource_id)
+        try:
+            if not dryrun:
+                response = snapshot.delete()
+                print(f'Response from snapshot.delete(): {str(response)}')
+            return True
+        except Exception as e:
+            print(f'Failure when calling snapshot.delete(): {str(e)}')
+            return False
+
+    # Check if a volume is stoppable (should always be false)
+    def is_stoppable(self, today_date, is_weekend=TODAY_IS_WEEKEND):
+        return self.generic_is_stoppable(self, today_date, is_weekend)
+
+    # Check if a snapshot is deletable/terminatable
+    def is_terminatable(self, today_date):
+        state = 'completed'
+        # TODO: question - since snapshot state is always completed pretty much, are they all
+        #   considered terminatable?
+        return self.generic_is_terminatable(self, state, today_date)
+
+    # Check if a volume is safe to stop (should always be false)
+    def is_safe_to_stop(self, today_date, is_weekend=TODAY_IS_WEEKEND):
+        return self.generic_is_safe_to_stop(self, today_date, is_weekend)
+
+    # Check if a snapshot is safe to delete/terminate
+    def is_safe_to_terminate(self, today_date):
+        resource_type = Snapshot
+        return self.generic_is_safe_to_terminate(self, resource_type, today_date)
+
+    # Create snapshot summary
+    def make_resource_summary(self):
+        resource_type = Snapshot
+        link = self.make_generic_resource_summary(self, resource_type)
+        state = f'State={self.state}'
+        line = f'{link}, {state}, Type={self.resource_type}'
+        return line
+
+    # Create snapshot url
+    @staticmethod
+    def url_from_id(region_name, resource_id):
+        resource_type = 'Snapshots'
+        return Resource.generic_url_from_id(region_name, resource_id, resource_type)
+
+    # Include volume in monthly price calculation if available
+    def included_in_monthly_price(self):
+        if self.state == 'completed':
+            return True
+        else:
+            return False

--- a/app/snapshot.py
+++ b/app/snapshot.py
@@ -155,6 +155,11 @@ class Snapshot(Resource):
     def is_active(self):
         return True if self.state == 'completed' else False
 
+    # Determine if resource can be stopped - Snapshots cannot be
+    @staticmethod
+    def can_be_stopped() -> bool:
+        return False
+
     # Create snapshot summary
     def make_resource_summary(self):
         resource_type = Snapshot

--- a/app/snapshot.py
+++ b/app/snapshot.py
@@ -121,8 +121,7 @@ class Snapshot(Resource):
         snapshot = ec2.Snapshot(self.resource_id)
         try:
             if not dryrun:
-                response = snapshot.delete()
-                print(f'Response from snapshot.delete(): {str(response)}')
+                snapshot.delete()  # delete() returns None
             return True
         except Exception as e:
             print(f'Failure when calling snapshot.delete(): {str(e)}')

--- a/app/snapshot.py
+++ b/app/snapshot.py
@@ -123,6 +123,9 @@ class Snapshot(Resource):
             print(f'Failure when calling snapshot.delete(): {str(e)}')
             return False
 
+    def is_stoppable_without_warning(self):
+        return self.generic_is_stoppable_without_warning(self)
+
     # Check if a volume is stoppable (should always be false)
     def is_stoppable(self, today_date, is_weekend=TODAY_IS_WEEKEND):
         return self.generic_is_stoppable(self, today_date, is_weekend)

--- a/app/snapshot.py
+++ b/app/snapshot.py
@@ -90,7 +90,7 @@ class Snapshot(Resource):
         elif "Copied for DestinationAmi" in resource_dict['Description']:
             is_ami_snapshot = True
 
-        monthly_price = resource.estimate_monthly_snapshot_price(snapshot_type, size)
+        monthly_price = estimate_monthly_snapshot_price(snapshot_type, size)
 
         snapshot = Resource.build_generic_model(tags, resource_dict, region_name, resource_id_tag, resource_type_tag)
 
@@ -177,3 +177,10 @@ class Snapshot(Resource):
             return True
         else:
             return False
+
+
+# Estimated monthly costs were formulated by taking the average monthly costs of N. California and Oregon
+def estimate_monthly_snapshot_price(type: str, size: float) -> float:
+    standard_monthly_cost = .0525
+    archive_monthly_cost = .0131
+    return standard_monthly_cost*size if type == "standard" else archive_monthly_cost*size

--- a/app/snapshot.py
+++ b/app/snapshot.py
@@ -139,6 +139,8 @@ class Snapshot(Resource):
 
     # Check if a snapshot is deletable/terminatable
     def is_terminatable(self, today_date):
+        if self.is_ami_snapshot or self.is_aws_backup_snapshot:
+            return False
         state = 'completed'
         return self.generic_is_terminatable(self, state, today_date)
 

--- a/app/snapshot.py
+++ b/app/snapshot.py
@@ -1,0 +1,8 @@
+@dataclass
+class Snapshot(Resource):
+    state: str
+    ec2_type: str
+    monthly_price: float
+    monthly_server_price: float
+    monthly_storage_price: float
+    size: float

--- a/app/volume.py
+++ b/app/volume.py
@@ -10,7 +10,6 @@ TODAY = datetime.today()
 TODAY_IS_WEEKEND = TODAY.weekday() >= 4  # Days are 0-6. 4=Friday, 5=Saturday, 6=Sunday, 0=Monday
 
 
-# Class representing an EBS volume
 @dataclass
 class Volume(Resource):
     state: str

--- a/app/volume.py
+++ b/app/volume.py
@@ -146,8 +146,8 @@ class Volume(Resource):
     def make_resource_summary(self):
         resource_type = Volume
         link = self.make_generic_resource_summary(self, resource_type)
-        state = 'State={}'.format(self.state)
-        line = '{}, {}, Type={}'.format(link, state, self.resource_type)
+        state = f'State={self.state}'
+        line = f'{link}, {state}, Type={resource_type}'
         return line
 
     # Create volume url

--- a/app/volume.py
+++ b/app/volume.py
@@ -148,6 +148,11 @@ class Volume(Resource):
     def is_active(self):
         return True if self.state == 'available' else False
 
+    # Determine if resource can be stopped - Volumes cannot be
+    @staticmethod
+    def can_be_stopped() -> bool:
+        return False
+
     # Create volume summary
     def make_resource_summary(self):
         resource_type = Volume

--- a/app/volume.py
+++ b/app/volume.py
@@ -144,6 +144,10 @@ class Volume(Resource):
         resource_type = Volume
         return self.generic_is_safe_to_terminate(self, resource_type, today_date)
 
+    # Check if a volume is active
+    def is_active(self):
+        return True if self.state == 'available' else False
+
     # Create volume summary
     def make_resource_summary(self):
         resource_type = Volume

--- a/app/volume.py
+++ b/app/volume.py
@@ -148,7 +148,7 @@ class Volume(Resource):
     def is_active(self):
         return True if self.state == 'available' else False
 
-    # Determine if resource can be stopped - Volumes cannot be
+    # Determine if resource has a 'stopped' state - Volumes don't
     @staticmethod
     def can_be_stopped() -> bool:
         return False

--- a/app/volume.py
+++ b/app/volume.py
@@ -34,7 +34,7 @@ class Volume(Resource):
                 'Monthly Price',
                 'Region Name',
                 'Volume Type',
-                'OS'
+                'OS',
                 'Size',
                 'IOPS',
                 'Throughput']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 boto3==1.20.26
+botocore==1.23.54
 slackclient==2.9.3
 pygsheets==2.0.5
 pytest==7.1.2

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -31,11 +31,11 @@ class TestAmi(unittest.TestCase):
                    )
 
     def test_stoppable_without_warning(self):
-        running_no_stop_after = self.setup_ami(state='running')
-        stopped_no_stop_after = self.setup_ami(state='stopped')
+        available_no_stop_after = self.setup_ami(state='available')
+        pending_no_stop_after = self.setup_ami(state='pending')
 
-        assert Ami.is_stoppable_without_warning(running_no_stop_after) is False
-        assert Ami.is_stoppable_without_warning(stopped_no_stop_after) is False
+        assert Ami.is_stoppable_without_warning(available_no_stop_after) is False
+        assert Ami.is_stoppable_without_warning(pending_no_stop_after) is False
 
     def test_stoppable(self):
         todays_date = nagbot.TODAY_YYYY_MM_DD

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -28,6 +28,7 @@ class TestAmi(unittest.TestCase):
                    terminate_after_tag_name=terminate_after_tag_name,
                    nagbot_state_tag_name='',
                    iops=1,
+                   volume_type='gp3',
                    throughput=125
                    )
 

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -29,7 +29,8 @@ class TestAmi(unittest.TestCase):
                    nagbot_state_tag_name='',
                    iops=1,
                    volume_type='gp3',
-                   throughput=125
+                   throughput=125,
+                   snapshots=[]
                    )
 
     def test_stoppable_without_warning(self):

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -1,0 +1,151 @@
+import unittest
+from unittest.mock import patch
+
+from app import resource
+from app import nagbot
+from app.ami import Ami
+
+
+class TestAmi(unittest.TestCase):
+    @staticmethod
+    def setup_ami(state: str, terminate_after: str = '', terminate_after_tag_name: str = ''):
+        return Ami(region_name='us-east-1',
+                   resource_id='def456',
+                   state=state,
+                   reason='',
+                   resource_type='machine',
+                   ec2_type='ami',
+                   name='Ali',
+                   operating_system='Windows',
+                   monthly_price=1,
+                   stop_after='',
+                   terminate_after=terminate_after,
+                   contact='Ali',
+                   nagbot_state='',
+                   eks_nodegroup_name='',
+                   stop_after_tag_name='',
+                   terminate_after_tag_name=terminate_after_tag_name,
+                   nagbot_state_tag_name='',
+                   iops=1,
+                   throughput=125
+                   )
+
+    def test_stoppable_without_warning(self):
+        running_no_stop_after = self.setup_ami(state='running')
+        stopped_no_stop_after = self.setup_ami(state='stopped')
+
+        assert Ami.is_stoppable_without_warning(running_no_stop_after) is False
+        assert Ami.is_stoppable_without_warning(stopped_no_stop_after) is False
+
+    def test_stoppable(self):
+        todays_date = nagbot.TODAY_YYYY_MM_DD
+        past_date = self.setup_ami(state='available', terminate_after='2019-01-01')
+        today_date = self.setup_ami(state='available', terminate_after=todays_date)
+
+        today_warning_str = ' (Nagbot: Warned on ' + todays_date + ')'
+        past_date_warned = self.setup_ami(state='available', terminate_after='2019-01-01' + today_warning_str)
+        today_date_warned = self.setup_ami(state='available',
+                                           terminate_after=todays_date + today_warning_str)
+        anything_warned = self.setup_ami(state='available', terminate_after='I Like lasagna' + today_warning_str)
+
+        old_warning_str = ' (Nagbot: Warned on ' + resource.MIN_TERMINATION_WARNING_YYYY_MM_DD + ')'
+        past_date_warned_days_ago = self.setup_ami(state='available', terminate_after='2019-01-01' +
+                                                   old_warning_str)
+        anything_warned_days_ago = self.setup_ami(state='available', terminate_after='I Like lasagna' +
+                                                  old_warning_str)
+
+        wrong_state = self.setup_ami(state='pending', terminate_after='2019-01-01')
+        future_date = self.setup_ami(state='available', terminate_after='2050-01-01')
+        unknown_date = self.setup_ami(state='available', terminate_after='TBD')
+
+        assert Ami.is_stoppable(past_date, todays_date) is False
+        assert Ami.is_stoppable(today_date, todays_date) is False
+        assert Ami.is_stoppable(past_date_warned, todays_date) is False
+        assert Ami.is_stoppable(today_date_warned, todays_date) is False
+        assert Ami.is_stoppable(anything_warned, todays_date) is False
+        assert Ami.is_stoppable(past_date_warned_days_ago, todays_date) is False
+        assert Ami.is_stoppable(anything_warned_days_ago, todays_date) is False
+        assert Ami.is_stoppable(wrong_state, todays_date) is False
+        assert Ami.is_stoppable(future_date, todays_date) is False
+        assert Ami.is_stoppable(unknown_date, todays_date) is False
+
+    def test_deletable(self):
+        todays_date = nagbot.TODAY_YYYY_MM_DD
+        past_date = self.setup_ami(state='available', terminate_after='2019-01-01')
+        today_date = self.setup_ami(state='available', terminate_after=todays_date)
+
+        today_warning_str = ' (Nagbot: Warned on ' + todays_date + ')'
+        past_date_warned = self.setup_ami(state='available', terminate_after='2019-01-01' + today_warning_str)
+        today_date_warned = self.setup_ami(state='available',
+                                              terminate_after=todays_date + today_warning_str)
+        anything_warned = self.setup_ami(state='available', terminate_after='I Like Lasagna' + today_warning_str)
+
+        old_warning_str = ' (Nagbot: Warned on ' + resource.MIN_TERMINATION_WARNING_YYYY_MM_DD + ')'
+        past_date_warned_days_ago = self.setup_ami(state='available', terminate_after='2019-01-01' +
+                                                                                         old_warning_str)
+        anything_warned_days_ago = self.setup_ami(state='available', terminate_after='I Like Pie' +
+                                                                                        old_warning_str)
+
+        wrong_state = self.setup_ami(state='pending', terminate_after='2019-01-01')
+        future_date = self.setup_ami(state='available', terminate_after='2050-01-01')
+        unknown_date = self.setup_ami(state='available', terminate_after='TBD')
+
+        # These amis should get a deletion warning
+        assert Ami.is_terminatable(past_date, todays_date) is True
+        assert Ami.is_terminatable(today_date, todays_date) is True
+        assert Ami.is_terminatable(past_date_warned, todays_date) is True
+        assert Ami.is_terminatable(today_date_warned, todays_date) is True
+
+        # These amis should NOT get a deletion warning
+        assert Ami.is_terminatable(wrong_state, todays_date) is False
+        assert Ami.is_terminatable(future_date, todays_date) is False
+        assert Ami.is_terminatable(unknown_date, todays_date) is False
+        assert Ami.is_terminatable(anything_warned, todays_date) is False
+
+        # These amis don't have a warning, so they shouldn't be deleted yet
+        assert Ami.is_safe_to_terminate(past_date, todays_date) is False
+        assert Ami.is_safe_to_terminate(today_date, todays_date) is False
+        assert Ami.is_safe_to_terminate(unknown_date, todays_date) is False
+        assert Ami.is_safe_to_terminate(wrong_state, todays_date) is False
+        assert Ami.is_safe_to_terminate(future_date, todays_date) is False
+        assert Ami.is_safe_to_terminate(anything_warned, todays_date) is False
+
+        # These amis can be deleted, but not yet
+        assert Ami.is_safe_to_terminate(past_date_warned, todays_date) is False
+        assert Ami.is_safe_to_terminate(today_date_warned, todays_date) is False
+
+        # These amis have a warning, but are not eligible to add a warning, so we don't delete
+        assert Ami.is_safe_to_terminate(anything_warned_days_ago, todays_date) is False
+
+        # These amis can be deleted now
+        assert Ami.is_safe_to_terminate(past_date_warned_days_ago, todays_date) is True
+
+    @staticmethod
+    @patch('app.ami.boto3.client')
+    def test_delete_ami(mock_client):
+        mock_ami = TestAmi.setup_ami(state='available')
+        mock_ec2 = mock_client.return_value
+
+        assert mock_ami.terminate_resource(dryrun=False)
+
+        mock_client.assert_called_once_with('ec2', region_name=mock_ami.region_name)
+        mock_ec2.delete_ami.assert_called_once_with(AmiId=mock_ami.resource_id)
+
+    @staticmethod
+    @patch('app.ami.boto3.client')
+    def test_delete_ami_exception(mock_client):
+        def raise_error():
+            raise RuntimeError('An error occurred (OperationNotPermitted)...')
+
+        mock_ami = TestAmi.setup_ami(state='available')
+        mock_ec2 = mock_client.return_value
+        mock_ec2.delete_ami.side_effect = lambda *args, **kw: raise_error()
+
+        assert not mock_ami.terminate_resource(dryrun=False)
+
+        mock_client.assert_called_once_with('ec2', region_name=mock_ami.region_name)
+        mock_ec2.delete_ami.assert_called_once_with(AmiId=mock_ami.resource_id)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -93,6 +93,11 @@ class TestSnapshot(unittest.TestCase):
         future_date = self.setup_snapshot(state='completed', terminate_after='2050-01-01')
         unknown_date = self.setup_snapshot(state='completed', terminate_after='TBD')
 
+        ami_snapshot = self.setup_snapshot(state='completed', terminate_after='2019-01-01')
+        ami_snapshot.__setattr__('is_ami_snapshot', True)
+        aws_backup_snapshot = self.setup_snapshot(state='completed', terminate_after='2019-01-01')
+        aws_backup_snapshot.__setattr__('is_aws_backup_snapshot', True)
+
         # These snapshots should get a deletion warning
         assert Snapshot.is_terminatable(past_date, todays_date) is True
         assert Snapshot.is_terminatable(today_date, todays_date) is True
@@ -104,6 +109,10 @@ class TestSnapshot(unittest.TestCase):
         assert Snapshot.is_terminatable(future_date, todays_date) is False
         assert Snapshot.is_terminatable(unknown_date, todays_date) is False
         assert Snapshot.is_terminatable(anything_warned, todays_date) is False
+
+        # These snapshots should not be deleted since they are aws backup or ami snapshots
+        assert Snapshot.is_terminatable(ami_snapshot, todays_date) is False
+        assert Snapshot.is_terminatable(aws_backup_snapshot, todays_date) is False
 
         # These snapshots don't have a warning, so they shouldn't be deleted yet
         assert Snapshot.is_safe_to_terminate(past_date, todays_date) is False

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -29,7 +29,9 @@ class TestSnapshot(unittest.TestCase):
                         nagbot_state_tag_name='',
                         size=1,
                         iops=1,
-                        throughput=125)
+                        throughput=125,
+                        is_ami_snapshot=False,
+                        is_aws_backup_snapshot=False)
 
     def test_stoppable_without_warning(self):
         completed_no_stop_after = self.setup_snapshot(state='completed')

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,151 @@
+import unittest
+from unittest.mock import patch
+
+from app import resource
+from app import nagbot
+from app.snapshot import Snapshot
+
+
+class TestSnapshot(unittest.TestCase):
+    @staticmethod
+    def setup_snapshot(state: str, terminate_after: str = '', terminate_after_tag_name: str = ''):
+        return Snapshot(region_name='us-east-1',
+                        resource_id='def456',
+                        state=state,
+                        reason='',
+                        resource_type='standard',
+                        ec2_type='snapshot',
+                        name='Ali',
+                        operating_system='Windows',
+                        monthly_price=1,
+                        stop_after='',
+                        terminate_after=terminate_after,
+                        contact='Ali',
+                        nagbot_state='',
+                        eks_nodegroup_name='',
+                        stop_after_tag_name='',
+                        terminate_after_tag_name=terminate_after_tag_name,
+                        nagbot_state_tag_name='',
+                        size=1,
+                        iops=1,
+                        throughput=125)
+
+    def test_stoppable_without_warning(self):
+        completed_no_stop_after = self.setup_snapshot(state='completed')
+        pending_no_stop_after = self.setup_snapshot(state='pending')
+
+        assert Snapshot.is_stoppable_without_warning(completed_no_stop_after) is False
+        assert Snapshot.is_stoppable_without_warning(pending_no_stop_after) is False
+
+    def test_stoppable(self):
+        todays_date = nagbot.TODAY_YYYY_MM_DD
+        past_date = self.setup_snapshot(state='completed', terminate_after='2019-01-01')
+        today_date = self.setup_snapshot(state='completed', terminate_after=todays_date)
+
+        today_warning_str = ' (Nagbot: Warned on ' + todays_date + ')'
+        past_date_warned = self.setup_snapshot(state='completed', terminate_after='2019-01-01' + today_warning_str)
+        today_date_warned = self.setup_snapshot(state='completed',
+                                                terminate_after=todays_date + today_warning_str)
+        anything_warned = self.setup_snapshot(state='completed', terminate_after='I Like Pie' + today_warning_str)
+
+        old_warning_str = ' (Nagbot: Warned on ' + resource.MIN_TERMINATION_WARNING_YYYY_MM_DD + ')'
+        past_date_warned_days_ago = self.setup_snapshot(state='completed', terminate_after='2019-01-01' +
+                                                                                           old_warning_str)
+        anything_warned_days_ago = self.setup_snapshot(state='completed', terminate_after='I Like Pie' +
+                                                                                          old_warning_str)
+
+        wrong_state = self.setup_snapshot(state='pending', terminate_after='2019-01-01')
+        future_date = self.setup_snapshot(state='completed', terminate_after='2050-01-01')
+        unknown_date = self.setup_snapshot(state='completed', terminate_after='TBD')
+
+        assert Snapshot.is_stoppable(past_date, todays_date) is False
+        assert Snapshot.is_stoppable(today_date, todays_date) is False
+        assert Snapshot.is_stoppable(past_date_warned, todays_date) is False
+        assert Snapshot.is_stoppable(today_date_warned, todays_date) is False
+        assert Snapshot.is_stoppable(anything_warned, todays_date) is False
+        assert Snapshot.is_stoppable(past_date_warned_days_ago, todays_date) is False
+        assert Snapshot.is_stoppable(anything_warned_days_ago, todays_date) is False
+        assert Snapshot.is_stoppable(wrong_state, todays_date) is False
+        assert Snapshot.is_stoppable(future_date, todays_date) is False
+        assert Snapshot.is_stoppable(unknown_date, todays_date) is False
+
+    def test_deletable(self):
+        todays_date = nagbot.TODAY_YYYY_MM_DD
+        past_date = self.setup_snapshot(state='completed', terminate_after='2019-01-01')
+        today_date = self.setup_snapshot(state='completed', terminate_after=todays_date)
+
+        today_warning_str = ' (Nagbot: Warned on ' + todays_date + ')'
+        past_date_warned = self.setup_snapshot(state='completed', terminate_after='2019-01-01' + today_warning_str)
+        today_date_warned = self.setup_snapshot(state='completed',
+                                                terminate_after=todays_date + today_warning_str)
+        anything_warned = self.setup_snapshot(state='completed', terminate_after='I Like Pie' + today_warning_str)
+
+        old_warning_str = ' (Nagbot: Warned on ' + resource.MIN_TERMINATION_WARNING_YYYY_MM_DD + ')'
+        past_date_warned_days_ago = self.setup_snapshot(state='completed', terminate_after='2019-01-01' +
+                                                                                           old_warning_str)
+        anything_warned_days_ago = self.setup_snapshot(state='completed', terminate_after='I Like Pie' +
+                                                                                          old_warning_str)
+
+        wrong_state = self.setup_snapshot(state='pending', terminate_after='2019-01-01')
+        future_date = self.setup_snapshot(state='completed', terminate_after='2050-01-01')
+        unknown_date = self.setup_snapshot(state='completed', terminate_after='TBD')
+
+        # These snapshots should get a deletion warning
+        assert Snapshot.is_terminatable(past_date, todays_date) is True
+        assert Snapshot.is_terminatable(today_date, todays_date) is True
+        assert Snapshot.is_terminatable(past_date_warned, todays_date) is True
+        assert Snapshot.is_terminatable(today_date_warned, todays_date) is True
+
+        # These snapshots should NOT get a deletion warning
+        assert Snapshot.is_terminatable(wrong_state, todays_date) is False
+        assert Snapshot.is_terminatable(future_date, todays_date) is False
+        assert Snapshot.is_terminatable(unknown_date, todays_date) is False
+        assert Snapshot.is_terminatable(anything_warned, todays_date) is False
+
+        # These snapshots don't have a warning, so they shouldn't be deleted yet
+        assert Snapshot.is_safe_to_terminate(past_date, todays_date) is False
+        assert Snapshot.is_safe_to_terminate(today_date, todays_date) is False
+        assert Snapshot.is_safe_to_terminate(unknown_date, todays_date) is False
+        assert Snapshot.is_safe_to_terminate(wrong_state, todays_date) is False
+        assert Snapshot.is_safe_to_terminate(future_date, todays_date) is False
+        assert Snapshot.is_safe_to_terminate(anything_warned, todays_date) is False
+
+        # These snapshots can be deleted, but not yet
+        assert Snapshot.is_safe_to_terminate(past_date_warned, todays_date) is False
+        assert Snapshot.is_safe_to_terminate(today_date_warned, todays_date) is False
+
+        # These snapshots have a warning, but are not eligible to add a warning, so we don't delete
+        assert Snapshot.is_safe_to_terminate(anything_warned_days_ago, todays_date) is False
+
+        # These snapshots can be deleted now
+        assert Snapshot.is_safe_to_terminate(past_date_warned_days_ago, todays_date) is True
+
+    @staticmethod
+    @patch('app.snapshot.boto3.client')
+    def test_delete_snapshot(mock_client):
+        mock_snapshot = TestSnapshot.setup_snapshot(state='completed')
+        mock_ec2 = mock_client.return_value
+
+        assert mock_snapshot.terminate_resource(dryrun=False)
+
+        mock_client.assert_called_once_with('ec2', region_name=mock_snapshot.region_name)
+        mock_ec2.delete_snapshot.assert_called_once_with(SnapshotId=mock_snapshot.resource_id)
+
+    @staticmethod
+    @patch('app.snapshot.boto3.client')
+    def test_delete_snapshot_exception(mock_client):
+        def raise_error():
+            raise RuntimeError('An error occurred (OperationNotPermitted)...')
+
+        mock_snapshot = TestSnapshot.setup_snapshot(state='completed')
+        mock_ec2 = mock_client.return_value
+        mock_ec2.delete_snapshot.side_effect = lambda *args, **kw: raise_error()
+
+        assert not mock_snapshot.terminate_resource(dryrun=False)
+
+        mock_client.assert_called_once_with('ec2', region_name=mock_snapshot.region_name)
+        mock_ec2.delete_snapshot.assert_called_once_with(SnapshotId=mock_snapshot.resource_id)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR introduces changes that allows NagBot to process AMIs and snapshots when issuing the 'execute' and 'notify' commands. 

**Pricing for Snapshots** was determined using the average price of storing _standard_ Snapshots in us-west-1, us-west-2, us-east-1, and us-east-2. I did not include logic to estimate the price of _archived_ snapshots since Seeq only uses standard snapshots to-date.

**Pricing for AMIs** was determined by taking the sum total price of the snapshots comprising the AMI. Only pricing for 
_EBS-Backed_ AMI's was implemented since Seeq does not use _instance-backed_ AMIs to-date.

**Terminating AMIs [considerations](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/deregister-ami.html#clean-up-ebs-ami)**:
- When you deregister an EBS-backed AMI, it doesn't affect the snapshot(s) that were created for the volume(s) of the instance during the AMI creation process. You'll continue to incur storage costs for the snapshots. I did not implement logic to explicitly delete the snapshots comprising EBS-backed AMIs since ideally those snapshots would have the same terminate date as the AMI upon creation. NagBot processes AMIs before snapshots, so the AMI would be deregistered then the snapshots comprising it would be deleted soon-after if they have the same terminate date. I can still implement the logic to also delete the snapshots when the AMI is deregistered if it sounds desirable, the snapshot ids are privided by the `boto3.resource.Image()` so it should only be a matter of calling `terminate_resource` on those snapshots.
**Note** After further discussion, functionality has been implemented in this PR so that any Snapshots making up an EBS-backed AMI are deleted when NagBot deregisters the AMI. Furthermore, pricing for Snapshots belonging to EBS-Backed AMIs are not included in the monthly Snapshot pricing, but they are instead included in the monthly AMI pricing.

**Terminating Snapshot [considerations](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-deleting-snapshot.html#ebs-delete-snapshot-considerations)**:
- You can't delete a snapshot of the root device of an EBS volume used by a registered AMI. You must first deregister the AMI before you can delete the snapshot. For this reason, AMI's are processed before snapshots when NagBot runs so that the AMI is deregistered before the snapshots comprising it are deleted. I didn't implement logic to deregister the AMI which the snapshot is a part of in this scenario, since the AMI and the snapshots it is composed of should have the same terminate date if we implement an AWS Lambda function in the future that automatically tags resources. Since AMIs are processed by NagBot first, the AMI would be deregistered if its terminate date comes up, then the snapshots would be able to be deleted - the snapshots would be deleted when NagBot processes our organizations snapshots.
- You can't delete a snapshot that is managed by the AWS Backup service using Amazon EC2. Instead, you must use AWS Backup to delete the corresponding recovery points in the backup vault - I did not implement logic for this scenario, but I imagine I could if it is desirable.

**Pytests have been written** for the `Snapshot` and `Ami` classes. 3/5 tests written for each class are identical to the tests written for the `Volume` class, with the exception of 2 tests involving terminating resources. Since AMIs and snapshots are deleted differently with the python `boto3` library than how EBS volumes and EC2 instances are deleted, I set the return value the aws `Snapshot()`and `Image()` classes to a MagicMock() - eventually it is asserted that the MagicMock() called `delete()` and `deregister()` for snapshots and ami respectively during `terminate_resource`.

**`README.md` has been updated** with instructions on how to update NagBot's version. Mentioning of volumes, AMIs, and snapshots has also been included in the README. A new slack app for testing NagBot has been created and added to the #bot-testing channel in slack., so the`README.md` was also updated with how to test NagBot during development, and where to find the `SLACK_BOT_TOKEN` for the NagBotTest slack app on Keeper.

**Some refactoring was done** as part of the changes in this PR so that `format()` strings were converted to f strings for readability.

---

Future Improvements: I noticed that our organization's snapshots and AMIs are often untagged, implementing a method of auto-tagging resources in the future (potentially using an AWS Lambda) would be beneficial to ensure those resources get tagged and deleted when they are no longer needed.