### PR TITLE
NO-CRAB: Fix 'You must specify a region' error by including region_name in function call

### DIFF
--- a/app/ami.py
+++ b/app/ami.py
@@ -224,8 +224,8 @@ def estimate_monthly_ami_price(ami_type: str, block_device_mappings: list, ami_n
     return total_cost
 
 
-def is_ami_registered(ami_id: str) -> bool:
-    ec2 = boto3.resource('ec2')
+def is_ami_registered(ami_id: str, region_name: str) -> bool:
+    ec2 = boto3.resource('ec2', region_name=region_name)
     is_registered = True
     # Retrieve name of AMI, if ClientError or AttributeError is thrown, the AMI does not exist
     try:

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -1,5 +1,5 @@
 __author__ = "Stephen Rosenthal"
-__version__ = "1.11.0"
+__version__ = "1.11.1"
 __license__ = "MIT"
 
 import argparse

--- a/app/snapshot.py
+++ b/app/snapshot.py
@@ -90,7 +90,8 @@ class Snapshot(Resource):
         monthly_price = estimate_monthly_snapshot_price(snapshot_type, size)
 
         snapshot = Resource.build_generic_model(tags, resource_dict, region_name, resource_id_tag, resource_type_tag)
-        is_aws_backup_snapshot, is_ami_snapshot = is_backup_or_ami_snapshot(snapshot.resource_id, resource_dict['Description'])
+        is_aws_backup_snapshot, is_ami_snapshot = \
+            is_backup_or_ami_snapshot(resource_dict['Description'], region_name)
 
         return Snapshot(region_name=region_name,
                         resource_id=snapshot.resource_id,
@@ -191,7 +192,7 @@ def estimate_monthly_snapshot_price(type: str, size: float) -> float:
 # Checks the snapshot description to see if the snapshot is part of an AMI or AWS backup.
 # If the snapshot is part of an AMI, but the AMI has been deregistered, then this function will return False
 # for is_ami_snapshot so the remaining snapshot can be cleaned up.
-def is_backup_or_ami_snapshot(name: str, description: str) -> bool:
+def is_backup_or_ami_snapshot(description: str, region_name: str) -> bool:
     is_aws_backup_snapshot = False
     is_ami_snapshot = False
     if "AWS Backup service" in description:
@@ -200,6 +201,6 @@ def is_backup_or_ami_snapshot(name: str, description: str) -> bool:
         # regex matches the first occurrence of ami, since the snapshot
         # belongs to the first mentioned ami (destination ami) and not the second (source ami)
         ami_id = re.search(r'ami-\S*', description).group()
-        is_ami_snapshot = ami.is_ami_registered(ami_id)
+        is_ami_snapshot = ami.is_ami_registered(ami_id, region_name)
 
     return is_aws_backup_snapshot, is_ami_snapshot


### PR DESCRIPTION
This PR fixes the `Nagbot failed to run the 'execute' command: You must specify a region.` error by including `region_name` when calling `boto3.resource()`. 
See [this slack conversation](https://seeq.slack.com/archives/C035SAF6TU3/p1667357185331209) for more information.
I've verified this was the problem by removing my `AWS_DEFAULT_REGION` env var then running, and it failed in #bot-testing [here](https://seeq.slack.com/archives/C03JPHX781Y/p1667361951987489), then when I added the 'region_name`, it passed in #bot-testing [here](https://seeq.slack.com/archives/C03JPHX781Y/p1667362293460269).