### PR TITLE
NO-CRAB: Resolve error that occurs during Snapshot termination

### DIFF
--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -1,5 +1,5 @@
 __author__ = "Stephen Rosenthal"
-__version__ = "1.11.1"
+__version__ = "1.11.2"
 __license__ = "MIT"
 
 import argparse

--- a/app/snapshot.py
+++ b/app/snapshot.py
@@ -118,7 +118,7 @@ class Snapshot(Resource):
 
     def terminate_resource(self, dryrun: bool) -> bool:
         print(f'Deleting snapshot: {str(self.resource_id)}...')
-        ec2 = boto3.client('ec2', region_name=self.region_name)
+        ec2 = boto3.resource('ec2', region_name=self.region_name)
         snapshot = ec2.Snapshot(self.resource_id)
         try:
             if not dryrun:

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -133,36 +133,36 @@ class TestSnapshot(unittest.TestCase):
         assert Snapshot.is_safe_to_terminate(past_date_warned_days_ago, todays_date) is True
 
     @staticmethod
-    @patch('app.snapshot.boto3.client')
-    def test_delete_snapshot(mock_client):
+    @patch('app.snapshot.boto3.resource')
+    def test_delete_snapshot(mock_resource):
         mock_snapshot = TestSnapshot.setup_snapshot(state='completed')
 
-        mock_ec2 = mock_client.return_value
+        mock_ec2 = mock_resource.return_value
         # _aws is included in variable name to differentiate between Snapshot class of NagBot and Snapshot class of AWS
         mock_snapshot_aws = MagicMock()
         mock_ec2.Snapshot.return_value = mock_snapshot_aws
 
         assert mock_snapshot.terminate_resource(dryrun=False)
 
-        mock_client.assert_called_once_with('ec2', region_name=mock_snapshot.region_name)
+        mock_resource.assert_called_once_with('ec2', region_name=mock_snapshot.region_name)
         mock_snapshot_aws.delete.assert_called_once()
 
     @staticmethod
-    @patch('app.snapshot.boto3.client')
-    def test_delete_snapshot_exception(mock_client):
+    @patch('app.snapshot.boto3.resource')
+    def test_delete_snapshot_exception(mock_resource):
         def raise_error():
             raise RuntimeError('An error occurred (OperationNotPermitted)...')
 
         mock_snapshot = TestSnapshot.setup_snapshot(state='completed')
 
-        mock_ec2 = mock_client.return_value
+        mock_ec2 = mock_resource.return_value
         mock_snapshot_aws = MagicMock()
         mock_ec2.Snapshot.return_value = mock_snapshot_aws
         mock_snapshot_aws.delete.side_effect = lambda *args, **kw: raise_error()
 
         assert not mock_snapshot.terminate_resource(dryrun=False)
 
-        mock_client.assert_called_once_with('ec2', region_name=mock_snapshot.region_name)
+        mock_resource.assert_called_once_with('ec2', region_name=mock_snapshot.region_name)
         mock_snapshot_aws.delete.assert_called_once()
 
 


### PR DESCRIPTION
When creating a snapshot object with a snapshot id, the object should be created using `boto3.resource()` rather than `boto3.client()`. 
The changes in this PR resolve the error that is being reported in the aws channel [here](https://seeq.slack.com/archives/CJX869FAM/p1667784729433649) that occurs when attempting to terminate a Snapshot. Pytests have been adjusted to reflect the changes, and are confirmed to be passing.