### PR TITLE
Fix bug for inability for NagBot to stop instances

### DIFF
--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -1,5 +1,5 @@
 __author__ = "Stephen Rosenthal"
-__version__ = "1.11.2"
+__version__ = "1.11.3"
 __license__ = "MIT"
 
 import argparse

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -117,7 +117,7 @@ class Nagbot(object):
             else:
                 sqslack.send_message(channel, f'No {ec2_type}s were terminated today.')
 
-            if resource_type == "Instance":
+            if resource_type.can_be_stopped():
                 if len(resources_to_stop) > 0:
                     message = f'I stopped the following {ec2_type}s: '
                     for r in resources_to_stop:


### PR DESCRIPTION
This PR fixes nagbot's inability to stop instances by using the can_be_stopped() method instead of string comparison, similar to how it is done in the notify command.