### PR TITLE
Provide an error message in slack output when NagBot can't stop / terminate resources

### DIFF
--- a/app/ami.py
+++ b/app/ami.py
@@ -133,7 +133,7 @@ class Ami(Resource):
                     snapshot.delete()  # delete() returns None
                 except Exception as e:
                     print(f'Failure when calling snapshot.delete(): {str(e)}')
-                    return e  # set to False and continue attempting to delete remaining Snapshots
+                    return e
         return True
 
     # Check if an ami is deletable/terminatable

--- a/app/ami.py
+++ b/app/ami.py
@@ -112,7 +112,7 @@ class Ami(Resource):
                    snapshot_ids=snapshot_ids)
 
     # Delete/terminate an AMI
-    def terminate_resource(self, dryrun: bool) -> bool:
+    def terminate_resource(self, dryrun: bool):
         print(f'Deleting AMI: {str(self.resource_id)} and any Snapshots it is composed of ...')
         ec2 = boto3.resource('ec2', region_name=self.region_name)
         image = ec2.Image(self.resource_id)
@@ -122,7 +122,7 @@ class Ami(Resource):
                 image.deregister()  # .deregister() returns None
         except Exception as e:
             print(f'Failure when calling image.deregister(): {str(e)}')
-            return e
+            return str(e)
 
         # Delete Snapshots making up the AMI once the AMI is deleted
         errors = ""
@@ -134,7 +134,7 @@ class Ami(Resource):
                     snapshot.delete()  # delete() returns None
                 except Exception as e:
                     print(f'Failure when calling snapshot.delete(): {str(e)}')
-                    errors += f"{e}\n"
+                    errors += f"{str(e)}\n"
         return errors if errors.strip() else True
 
     # Check if an ami is deletable/terminatable

--- a/app/ami.py
+++ b/app/ami.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 
 import app.snapshot
-from app import parsing
 from app import util
+from typing import Union
 from .resource import Resource
 import boto3
 
@@ -112,7 +112,7 @@ class Ami(Resource):
                    snapshot_ids=snapshot_ids)
 
     # Delete/terminate an AMI
-    def terminate_resource(self, dryrun: bool):
+    def terminate_resource(self, dryrun: bool) -> Union[None, str]:
         print(f'Deleting AMI: {str(self.resource_id)} and any Snapshots it is composed of ...')
         ec2 = boto3.resource('ec2', region_name=self.region_name)
         image = ec2.Image(self.resource_id)
@@ -125,7 +125,7 @@ class Ami(Resource):
             return str(e)
 
         # Delete Snapshots making up the AMI once the AMI is deleted
-        errors = ""
+        errors = []
         if not dryrun:
             for snapshot_id in self.snapshot_ids:
                 snapshot = ec2.Snapshot(snapshot_id)
@@ -134,8 +134,8 @@ class Ami(Resource):
                     snapshot.delete()  # delete() returns None
                 except Exception as e:
                     print(f'Failure when calling snapshot.delete(): {str(e)}')
-                    errors += f"{str(e)}\n"
-        return errors if errors.strip() else True
+                    errors.append(str(e))
+        return '\n'.join(errors) if errors else None
 
     # Check if an ami is deletable/terminatable
     def can_be_terminated(self, today_date=util.TODAY_YYYY_MM_DD):

--- a/app/ami.py
+++ b/app/ami.py
@@ -125,6 +125,7 @@ class Ami(Resource):
             return e
 
         # Delete Snapshots making up the AMI once the AMI is deleted
+        errors = ""
         if not dryrun:
             for snapshot_id in self.snapshot_ids:
                 snapshot = ec2.Snapshot(snapshot_id)
@@ -133,8 +134,8 @@ class Ami(Resource):
                     snapshot.delete()  # delete() returns None
                 except Exception as e:
                     print(f'Failure when calling snapshot.delete(): {str(e)}')
-                    return e
-        return True
+                    errors += f"{e}\n"
+        return errors if errors.strip() else True
 
     # Check if an ami is deletable/terminatable
     def can_be_terminated(self, today_date=util.TODAY_YYYY_MM_DD):

--- a/app/ami.py
+++ b/app/ami.py
@@ -122,10 +122,9 @@ class Ami(Resource):
                 image.deregister()  # .deregister() returns None
         except Exception as e:
             print(f'Failure when calling image.deregister(): {str(e)}')
-            return False
+            return e
 
         # Delete Snapshots making up the AMI once the AMI is deleted
-        snapshots_deleted = True
         if not dryrun:
             for snapshot_id in self.snapshot_ids:
                 snapshot = ec2.Snapshot(snapshot_id)
@@ -134,8 +133,8 @@ class Ami(Resource):
                     snapshot.delete()  # delete() returns None
                 except Exception as e:
                     print(f'Failure when calling snapshot.delete(): {str(e)}')
-                    snapshots_deleted = False  # set to False and continue attempting to delete remaining Snapshots
-        return snapshots_deleted
+                    return e  # set to False and continue attempting to delete remaining Snapshots
+        return True
 
     # Check if an ami is deletable/terminatable
     def can_be_terminated(self, today_date=util.TODAY_YYYY_MM_DD):

--- a/app/instance.py
+++ b/app/instance.py
@@ -133,7 +133,7 @@ class Instance(Resource):
             return True
         except Exception as e:
             print(f'Failure when calling terminate_instances: {str(e)}')
-            return False
+            return e
 
     # Instance with no stop after tag should be stopped immediately
     def is_stoppable_without_warning(self, is_weekend):

--- a/app/instance.py
+++ b/app/instance.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from app import parsing
 from app import util
+from typing import Union
 from .resource import Resource
 from .volume import estimate_monthly_ebs_storage_price
 import boto3
@@ -123,14 +124,14 @@ class Instance(Resource):
                         throughput=instance.throughput)
 
     # Terminate an EC2 instance
-    def terminate_resource(self, dryrun: bool):
+    def terminate_resource(self, dryrun: bool) -> Union[None, str]:
         print(f'Terminating instance: {str(self.resource_id)}...')
         ec2 = boto3.client('ec2', region_name=self.region_name)
         try:
             if not dryrun:
                 response = ec2.terminate_instances(InstanceIds=[self.resource_id])
                 print(f'Response from terminate_instances: {str(response)}')
-            return True
+            return None
         except Exception as e:
             print(f'Failure when calling terminate_instances: {str(e)}')
             return str(e)

--- a/app/instance.py
+++ b/app/instance.py
@@ -123,7 +123,7 @@ class Instance(Resource):
                         throughput=instance.throughput)
 
     # Terminate an EC2 instance
-    def terminate_resource(self, dryrun: bool) -> bool:
+    def terminate_resource(self, dryrun: bool):
         print(f'Terminating instance: {str(self.resource_id)}...')
         ec2 = boto3.client('ec2', region_name=self.region_name)
         try:
@@ -133,7 +133,7 @@ class Instance(Resource):
             return True
         except Exception as e:
             print(f'Failure when calling terminate_instances: {str(e)}')
-            return e
+            return str(e)
 
     # Instance with no stop after tag should be stopped immediately
     def is_stoppable_without_warning(self, is_weekend):

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -1,5 +1,5 @@
 __author__ = "Stephen Rosenthal"
-__version__ = "1.11.4"
+__version__ = "1.11.5"
 __license__ = "MIT"
 
 import argparse

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -117,7 +117,7 @@ class Nagbot(object):
                 message = f'I terminated the following {ec2_type}s: '
                 for r in resources_to_terminate:
                     response = r.terminate_resource(dryrun=dryrun)
-                    if response is not True:
+                    if response:
                         message = message + f"Error when attempting to terminate {r.make_resource_summary()}:" \
                                             f" {response}\n"
                     else:

--- a/app/nagbot.py
+++ b/app/nagbot.py
@@ -116,11 +116,15 @@ class Nagbot(object):
             if len(resources_to_terminate) > 0:
                 message = f'I terminated the following {ec2_type}s: '
                 for r in resources_to_terminate:
-                    contact = sqslack.lookup_user_by_email(r.contact)
-                    message = message + r.make_resource_summary() + \
-                        f', "Terminate after"={r.terminate_after}, "Monthly Price"=' \
-                        f'{util.money_to_string(r.monthly_price)}, Contact={contact}\n'
-                    r.terminate_resource(dryrun=dryrun)
+                    response = r.terminate_resource(dryrun=dryrun)
+                    if response is not True:
+                        message = message + f"Error when attempting to terminate {r.make_resource_summary()}:" \
+                                            f" {response}\n"
+                    else:
+                        contact = sqslack.lookup_user_by_email(r.contact)
+                        message = message + r.make_resource_summary() + \
+                            f', "Terminate after"={r.terminate_after}, "Monthly Price"=' \
+                            f'{util.money_to_string(r.monthly_price)}, Contact={contact}\n'
                 sqslack.send_message(channel, message)
             else:
                 sqslack.send_message(channel, f'No {ec2_type}s were terminated today.')
@@ -129,12 +133,16 @@ class Nagbot(object):
                 if len(resources_to_stop) > 0:
                     message = f'I stopped the following {ec2_type}s: '
                     for r in resources_to_stop:
-                        contact = sqslack.lookup_user_by_email(r.contact)
-                        message = message + r.make_resource_summary() + \
-                            f', "Stop after"={r.stop_after}, "Monthly Price"={r.monthly_price}, Contact={contact}\n'
-                        util.stop_resource(r.region_name, r.resource_id, dryrun=dryrun)
-                        util.set_tag(r.region_name, r.ec2_type, r.resource_id, r.nagbot_state_tag_name,
-                                     f'Stopped on {util.TODAY_YYYY_MM_DD}', dryrun=dryrun)
+                        response = util.stop_resource(r.region_name, r.resource_id, dryrun=dryrun)
+                        if response is not True:
+                            message = message + f"Error when attempting to stop " \
+                                                f"{r.make_resource_summary()}: {response}\n"
+                        else:
+                            util.set_tag(r.region_name, r.ec2_type, r.resource_id, r.nagbot_state_tag_name,
+                                         f'Stopped on {util.TODAY_YYYY_MM_DD}', dryrun=dryrun)
+                            contact = sqslack.lookup_user_by_email(r.contact)
+                            message = message + r.make_resource_summary() + \
+                                f', "Stop after"={r.stop_after}, "Monthly Price"={r.monthly_price}, Contact={contact}\n'
                     sqslack.send_message(channel, message)
                 else:
                     sqslack.send_message(channel, f'No {ec2_type}s were stopped today.')

--- a/app/snapshot.py
+++ b/app/snapshot.py
@@ -124,7 +124,7 @@ class Snapshot(Resource):
             return True
         except Exception as e:
             print(f'Failure when calling snapshot.delete(): {str(e)}')
-            return False
+            return e
 
     # Check if a snapshot is deletable/terminatable
     def can_be_terminated(self, today_date=util.TODAY_YYYY_MM_DD):

--- a/app/snapshot.py
+++ b/app/snapshot.py
@@ -124,7 +124,7 @@ class Snapshot(Resource):
             return True
         except Exception as e:
             print(f'Failure when calling snapshot.delete(): {str(e)}')
-            return e
+            return str(e)
 
     # Check if a snapshot is deletable/terminatable
     def can_be_terminated(self, today_date=util.TODAY_YYYY_MM_DD):

--- a/app/snapshot.py
+++ b/app/snapshot.py
@@ -1,11 +1,10 @@
 from dataclasses import dataclass
 
-from app import parsing
 from app import util
+from typing import Union
 from .resource import Resource
 
 import boto3
-import re
 
 
 @dataclass
@@ -114,14 +113,14 @@ class Snapshot(Resource):
                         is_ami_snapshot=is_ami_snapshot,
                         is_aws_backup_snapshot=is_aws_backup_snapshot)
 
-    def terminate_resource(self, dryrun: bool) -> bool:
+    def terminate_resource(self, dryrun: bool) -> Union[None, str]:
         print(f'Deleting snapshot: {str(self.resource_id)}...')
         ec2 = boto3.resource('ec2', region_name=self.region_name)
         snapshot = ec2.Snapshot(self.resource_id)
         try:
             if not dryrun:
                 snapshot.delete()  # delete() returns None
-            return True
+            return None
         except Exception as e:
             print(f'Failure when calling snapshot.delete(): {str(e)}')
             return str(e)

--- a/app/util.py
+++ b/app/util.py
@@ -47,7 +47,7 @@ def get_tag_names(tags: dict) -> tuple:
     return stop_after_tag_name, terminate_after_tag_name, nagbot_state_tag_name
 
 
-def stop_resource(region_name: str, instance_id: str, dryrun: bool) -> bool:
+def stop_resource(region_name: str, instance_id: str, dryrun: bool):
     print(f'Stopping instance: {str(instance_id)}...')
     ec2 = boto3.client('ec2', region_name=region_name)
     try:
@@ -57,7 +57,7 @@ def stop_resource(region_name: str, instance_id: str, dryrun: bool) -> bool:
         return True
     except Exception as e:
         print(f'Failure when calling stop_instances: {str(e)}')
-        return e
+        return str(e)
 
 
 def has_date_passed(date_to_check, today_date=TODAY_YYYY_MM_DD):

--- a/app/util.py
+++ b/app/util.py
@@ -57,7 +57,7 @@ def stop_resource(region_name: str, instance_id: str, dryrun: bool) -> bool:
         return True
     except Exception as e:
         print(f'Failure when calling stop_instances: {str(e)}')
-        return False
+        return e
 
 
 def has_date_passed(date_to_check, today_date=TODAY_YYYY_MM_DD):

--- a/app/volume.py
+++ b/app/volume.py
@@ -121,7 +121,7 @@ class Volume(Resource):
             return True
         except Exception as e:
             print(f'Failure when calling delete_volumes: {str(e)}')
-            return False
+            return e
 
     # Check if a volume is deletable/terminatable without warning
     def can_be_terminated(self, today_date=util.TODAY_YYYY_MM_DD):

--- a/app/volume.py
+++ b/app/volume.py
@@ -111,7 +111,7 @@ class Volume(Resource):
                       throughput=volume.throughput)
 
     # Delete/terminate an EBS volume
-    def terminate_resource(self, dryrun: bool) -> bool:
+    def terminate_resource(self, dryrun: bool):
         print(f'Deleting volume: {str(self.resource_id)}...')
         ec2 = boto3.client('ec2', region_name=self.region_name)
         try:
@@ -121,7 +121,7 @@ class Volume(Resource):
             return True
         except Exception as e:
             print(f'Failure when calling delete_volumes: {str(e)}')
-            return e
+            return str(e)
 
     # Check if a volume is deletable/terminatable without warning
     def can_be_terminated(self, today_date=util.TODAY_YYYY_MM_DD):

--- a/app/volume.py
+++ b/app/volume.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
-from app import parsing
 from app import util
+from typing import Union
 from .resource import Resource
 import boto3
 
@@ -111,14 +111,14 @@ class Volume(Resource):
                       throughput=volume.throughput)
 
     # Delete/terminate an EBS volume
-    def terminate_resource(self, dryrun: bool):
+    def terminate_resource(self, dryrun: bool) -> Union [None, str]:
         print(f'Deleting volume: {str(self.resource_id)}...')
         ec2 = boto3.client('ec2', region_name=self.region_name)
         try:
             if not dryrun:
                 response = ec2.delete_volume(VolumeId=self.resource_id)
                 print(f'Response from delete_volumes: {str(response)}')
-            return True
+            return None
         except Exception as e:
             print(f'Failure when calling delete_volumes: {str(e)}')
             return str(e)

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -154,7 +154,7 @@ class TestAmi(unittest.TestCase):
         mock_image.deregister.side_effect = lambda *args, **kw: raise_error()
         mock_snapshot.delete.side_effect = lambda *args, **kw: raise_error()
 
-        assert not mock_ami.terminate_resource(dryrun=False)
+        assert mock_ami.terminate_resource(dryrun=False) is not True
 
         mock_resource.assert_called_once_with('ec2', region_name=mock_ami.region_name)
         mock_image.deregister.assert_called_once()

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -132,7 +132,7 @@ class TestAmi(unittest.TestCase):
         mock_ec2.Image.return_value = mock_image
         mock_ec2.Snapshot.return_value = mock_snapshot
 
-        assert mock_ami.terminate_resource(dryrun=False)
+        assert mock_ami.terminate_resource(dryrun=False) is None
 
         mock_resource.assert_called_once_with('ec2', region_name=mock_ami.region_name)
         mock_image.deregister.assert_called_once()
@@ -154,7 +154,7 @@ class TestAmi(unittest.TestCase):
         mock_image.deregister.side_effect = lambda *args, **kw: raise_error()
         mock_snapshot.delete.side_effect = lambda *args, **kw: raise_error()
 
-        assert mock_ami.terminate_resource(dryrun=False) is not True
+        assert mock_ami.terminate_resource(dryrun=False) is not None
 
         mock_resource.assert_called_once_with('ec2', region_name=mock_ami.region_name)
         mock_image.deregister.assert_called_once()

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -170,7 +170,7 @@ class TestInstance(unittest.TestCase):
         mock_instance = TestInstance.setup_instance(state='stopped')
         mock_ec2 = mock_client.return_value
 
-        assert mock_instance.terminate_resource(dryrun=False)
+        assert mock_instance.terminate_resource(dryrun=False) is None
 
         mock_client.assert_called_once_with('ec2', region_name=mock_instance.region_name)
         mock_ec2.terminate_instances.assert_called_once_with(InstanceIds=[mock_instance.resource_id])
@@ -187,7 +187,7 @@ class TestInstance(unittest.TestCase):
         mock_ec2 = mock_client.return_value
         mock_ec2.terminate_instances.side_effect = lambda *args, **kw: raise_error()
 
-        assert mock_instance.terminate_resource(dryrun=False) is not True
+        assert mock_instance.terminate_resource(dryrun=False) is not None
 
         mock_client.assert_called_once_with('ec2', region_name=mock_instance.region_name)
         mock_ec2.terminate_instances.assert_called_once_with(InstanceIds=[mock_instance.resource_id])

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -187,7 +187,7 @@ class TestInstance(unittest.TestCase):
         mock_ec2 = mock_client.return_value
         mock_ec2.terminate_instances.side_effect = lambda *args, **kw: raise_error()
 
-        assert not mock_instance.terminate_resource(dryrun=False)
+        assert mock_instance.terminate_resource(dryrun=False) is not True
 
         mock_client.assert_called_once_with('ec2', region_name=mock_instance.region_name)
         mock_ec2.terminate_instances.assert_called_once_with(InstanceIds=[mock_instance.resource_id])

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -59,7 +59,7 @@ def test_stop_instance_exception(mock_client):
     mock_ec2 = mock_client.return_value
     mock_ec2.stop_instances.side_effect = lambda *args, **kw: raise_error()
 
-    assert not util.stop_resource(region_name, instance_id, dryrun=False)
+    assert util.stop_resource(region_name, instance_id, dryrun=False) is not True
 
     mock_client.assert_called_once_with('ec2', region_name=region_name)
     mock_ec2.stop_instances.assert_called_once_with(InstanceIds=[instance_id])

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -160,7 +160,7 @@ class TestSnapshot(unittest.TestCase):
         mock_ec2.Snapshot.return_value = mock_snapshot_aws
         mock_snapshot_aws.delete.side_effect = lambda *args, **kw: raise_error()
 
-        assert not mock_snapshot.terminate_resource(dryrun=False)
+        assert mock_snapshot.terminate_resource(dryrun=False) is not True
 
         mock_resource.assert_called_once_with('ec2', region_name=mock_snapshot.region_name)
         mock_snapshot_aws.delete.assert_called_once()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -142,7 +142,7 @@ class TestSnapshot(unittest.TestCase):
         mock_snapshot_aws = MagicMock()
         mock_ec2.Snapshot.return_value = mock_snapshot_aws
 
-        assert mock_snapshot.terminate_resource(dryrun=False)
+        assert mock_snapshot.terminate_resource(dryrun=False) is None
 
         mock_resource.assert_called_once_with('ec2', region_name=mock_snapshot.region_name)
         mock_snapshot_aws.delete.assert_called_once()
@@ -160,7 +160,7 @@ class TestSnapshot(unittest.TestCase):
         mock_ec2.Snapshot.return_value = mock_snapshot_aws
         mock_snapshot_aws.delete.side_effect = lambda *args, **kw: raise_error()
 
-        assert mock_snapshot.terminate_resource(dryrun=False) is not True
+        assert mock_snapshot.terminate_resource(dryrun=False) is not None
 
         mock_resource.assert_called_once_with('ec2', region_name=mock_snapshot.region_name)
         mock_snapshot_aws.delete.assert_called_once()

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -128,7 +128,7 @@ class TestVolume(unittest.TestCase):
         mock_volume = TestVolume.setup_volume(state='available')
         mock_ec2 = mock_client.return_value
 
-        assert mock_volume.terminate_resource(dryrun=False)
+        assert mock_volume.terminate_resource(dryrun=False) is None
 
         mock_client.assert_called_once_with('ec2', region_name=mock_volume.region_name)
         mock_ec2.delete_volume.assert_called_once_with(VolumeId=mock_volume.resource_id)
@@ -143,7 +143,7 @@ class TestVolume(unittest.TestCase):
         mock_ec2 = mock_client.return_value
         mock_ec2.delete_volume.side_effect = lambda *args, **kw: raise_error()
 
-        assert mock_volume.terminate_resource(dryrun=False) is not True
+        assert mock_volume.terminate_resource(dryrun=False) is not None
 
         mock_client.assert_called_once_with('ec2', region_name=mock_volume.region_name)
         mock_ec2.delete_volume.assert_called_once_with(VolumeId=mock_volume.resource_id)

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -143,7 +143,7 @@ class TestVolume(unittest.TestCase):
         mock_ec2 = mock_client.return_value
         mock_ec2.delete_volume.side_effect = lambda *args, **kw: raise_error()
 
-        assert not mock_volume.terminate_resource(dryrun=False)
+        assert mock_volume.terminate_resource(dryrun=False) is not True
 
         mock_client.assert_called_once_with('ec2', region_name=mock_volume.region_name)
         mock_ec2.delete_volume.assert_called_once_with(VolumeId=mock_volume.resource_id)


### PR DESCRIPTION
With the changes in this PR, an error message will be included in the message sent to slack when nagbot runs into trouble stopping / terminating resources. 

In each of the resource's terminate and stop methods, `True` is returned if the resource is terminated, and the error message is returned if an error occurs during termination / stopping. That error message, and the resource it pertains to, is included in the final slack message.

The pytests have been updated to reflect the new changes.