### PR TITLE
CRAB-46176: Update actions dependencies to latest versions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: mr-smithers-excellent/docker-build-push@v6
       with:
         image: ${{ secrets.DOCKERHUB_USERNAME }}/nagbot

--- a/.github/workflows/python-unittest.yml
+++ b/.github/workflows/python-unittest.yml
@@ -7,9 +7,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v2.3.1    
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       id: cache-venv
       with:
         path: ./venv/

--- a/.github/workflows/python-unittest.yml
+++ b/.github/workflows/python-unittest.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v2.3.1    
     - uses: actions/cache@v4
       id: cache-venv


### PR DESCRIPTION
Starting February 1st, 2025, v1-v2 of [actions/cache](https://nam10.safelinks.protection.outlook.com/?url=https%3A%2F%2Fapp.github.media%2Fe%2Fer%3Fs%3D88570519%26lid%3D6814%26elqTrackId%3Da3bc821626b94473987e2c1b05d7f97a%26elq%3D209f648fe0e14069a03443126e090b8d%26elqaid%3D4282%26elqat%3D1%26elqak%3D8AF5A5B4BDB0473BC910C050E532EFF49739E292F9C463AE35AAFA8A7421FBBF4E9F&data=05%7C02%7Cmike.kuth%40seeq.com%7C57362754bef34e0faa4208dd1955aa4c%7C59c342741c79484b8ed671174050b6d6%7C0%7C0%7C638694577929345860%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=a35%2FqinXhS%2BNKG4X8ndLJgrXesDtYzGdBqOeqlcfXXU%3D&reserved=0) are being closed down, so this PR upgrades us to the latest version. Also went ahead and upgraded the other actions dependency since it would be good to stay on top of that.  