### PR TITLE
CRAB-50678: Report instances stopped for more than 6 months

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-boto3>=1.34.0
-botocore>=1.34.0
-slackclient==2.9.3
-pygsheets==2.0.5
-pytest==7.1.2
-pytz==2022.4
-XlsxWriter==3.0.3
+boto3==1.40.15
+botocore==1.40.15
+slackclient==2.9.4
+pygsheets==2.0.6
+pytest==8.4.2
+pytz==2025.2
+XlsxWriter==3.2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-boto3==1.20.26
-botocore==1.23.54
+boto3>=1.34.0
+botocore>=1.34.0
 slackclient==2.9.3
 pygsheets==2.0.5
 pytest==7.1.2


### PR DESCRIPTION
This PR updates nagbot to check for instances stopped for more than 6 months - on 1st and 15th of every month. Sends a summary of all those instances with tagging owners.